### PR TITLE
ユーザー情報更新API（userId, Name, Password）

### DIFF
--- a/backend/src/domain/account/account.ts
+++ b/backend/src/domain/account/account.ts
@@ -54,7 +54,7 @@ export class Account {
     name: string | undefined,
     hashedPassword: string | undefined,
     organizationId: string | undefined,
-    role: Role
+    role: Role | undefined
   ): Result<Account, Error> {
     const updatedUserId = userId ?? this.userId;
     const updatedName = name ?? this.name;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import { OrganizationListQueryImpl } from "./usecase/organization/query/get-list
 import { OrganizationProfileQueryImpl } from "./usecase/organization/query/get-profile.js";
 import { UserCreateCommandImpl } from "./usecase/user/command/create.js";
 import { UserUpdateRoleCommandImpl } from "./usecase/user/command/update-role.js";
+import { UserUpdateCommandImpl } from "./usecase/user/command/update.js";
 
 const app = new Hono<Env>();
 
@@ -54,8 +55,9 @@ const userCreateCommand = new UserCreateCommandImpl(
   organizationRepository,
   passwordHash
 );
+const userUpdateCommand = new UserUpdateCommandImpl(accountRepository, passwordHash);
 const userUpdateRoleCommand = new UserUpdateRoleCommandImpl(accountRepository);
-const userHandler = new UserHandler(userCreateCommand, userUpdateRoleCommand);
+const userHandler = new UserHandler(userCreateCommand, userUpdateCommand, userUpdateRoleCommand);
 
 initRouting(app, authHandler, organizationHandler, userHandler, jwtService, accountRepository);
 

--- a/backend/src/infrastructure/account/account-repository-impl.ts
+++ b/backend/src/infrastructure/account/account-repository-impl.ts
@@ -31,7 +31,7 @@ export class AccountRepositoryImpl implements AccountRepository {
       }
 
       return ok(data.value);
-    } catch (error) {
+    } catch {
       return err(new UnexpectedError());
     }
   }

--- a/backend/src/presentation/handlers/user-handler.ts
+++ b/backend/src/presentation/handlers/user-handler.ts
@@ -41,11 +41,11 @@ export class UserHandler {
   }
 
   async updateUser(c: Context) {
+    const account = c.get("account");
     const body = await c.req.json();
-    const id = c.req.param("id");
 
     const result = await this.userUpdateCommand.execute(
-      id,
+      account,
       body.userId || undefined,
       body.name || undefined,
       body.password || undefined

--- a/backend/src/presentation/middleware/permission.ts
+++ b/backend/src/presentation/middleware/permission.ts
@@ -50,11 +50,12 @@ const permissionPolicy = (actor: Account, action: Action, resource: Resource): b
         break;
       case "update":
         if (
-          actor.role === "Manager" &&
-          actor.organizationId === resource.content?.organizationId &&
-          (resource.content?.role === "Manager" || resource.content?.role === "Operator") &&
-          (resource.content?.roleGranted === "Manager" ||
-            resource.content?.roleGranted === "Operator")
+          (actor.id === resource.content?.id && resource.content?.roleGranted === undefined) ||
+          (actor.role === "Manager" &&
+            actor.organizationId === resource.content?.organizationId &&
+            (resource.content?.role === "Manager" || resource.content?.role === "Operator") &&
+            (resource.content?.roleGranted === "Manager" ||
+              resource.content?.roleGranted === "Operator"))
         ) {
           return true;
         }

--- a/backend/src/presentation/routes.ts
+++ b/backend/src/presentation/routes.ts
@@ -119,6 +119,24 @@ export function initRouting(
     (c) => userHandler.createUser(c)
   );
   app.put(
+    "/user/:id",
+    zValidator("param", z.object({ id: z.string().uuid() }), (result, c) => {
+      if (!result.success) {
+        const error = new BadRequestError();
+        return c.json({ message: error.message }, error.statusCode);
+      }
+    }),
+    zValidator("json", schemas.UpdateUserRequest, (result, c) => {
+      if (!result.success) {
+        const error = new BadRequestError();
+        return c.json({ message: error.message }, error.statusCode);
+      }
+    }),
+    jwtMiddleware(jwtService),
+    accountPermissionMiddleware("update", accountRepository),
+    (c) => userHandler.updateUser(c)
+  );
+  app.put(
     "/user-role/:id",
     zValidator("param", z.object({ id: z.string().uuid() }), (result, c) => {
       if (!result.success) {

--- a/backend/src/presentation/routes.ts
+++ b/backend/src/presentation/routes.ts
@@ -133,7 +133,8 @@ export function initRouting(
       }
     }),
     jwtMiddleware(jwtService),
-    accountPermissionMiddleware("update", accountRepository),
+    accountGetMiddleware(accountRepository),
+    accountPermissionMiddleware("update"),
     (c) => userHandler.updateUser(c)
   );
   app.put(

--- a/backend/src/usecase/user/command/update-role.test.ts
+++ b/backend/src/usecase/user/command/update-role.test.ts
@@ -43,34 +43,15 @@ describe("UserUpdateRoleCommandImpl", () => {
       mockRole
     )._unsafeUnwrap();
 
-    mockAccountRepository.findById.mockResolvedValue(ok(mockData));
     mockAccountRepository.save.mockResolvedValue(ok(mockNewData));
 
-    const result = await userUpdateRoleCommand.execute(mockId, mockRole);
+    const result = await userUpdateRoleCommand.execute(mockData, mockRole);
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       const account = result.value;
       expect(account).toEqual(mockNewData);
-      expect(mockAccountRepository.findById).toHaveBeenCalledWith(mockId);
       expect(mockAccountRepository.save).toHaveBeenCalledWith(mockNewData);
-    }
-  });
-
-  it("ユーザーが存在しない場合", async () => {
-    const userUpdateRoleCommand = new UserUpdateRoleCommandImpl(mockAccountRepository);
-
-    const mockId = "mock-uuid-123";
-    const mockRole = "Manager";
-
-    mockAccountRepository.findById.mockResolvedValue(err(new UnExistUserError()));
-
-    const result = await userUpdateRoleCommand.execute(mockId, mockRole);
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error).toBeInstanceOf(UnExistUserError);
-      expect(mockAccountRepository.findById).toHaveBeenCalledWith(mockId);
     }
   });
 
@@ -88,15 +69,13 @@ describe("UserUpdateRoleCommandImpl", () => {
       mockRole
     )._unsafeUnwrap();
 
-    mockAccountRepository.findById.mockResolvedValue(ok(mockData));
     mockAccountRepository.save.mockResolvedValue(err(new UnexpectedError()));
 
-    const result = await userUpdateRoleCommand.execute(mockId, mockRole);
+    const result = await userUpdateRoleCommand.execute(mockData, mockRole);
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(UnexpectedError);
-      expect(mockAccountRepository.findById).toHaveBeenCalledWith(mockId);
       expect(mockAccountRepository.save).toHaveBeenCalledWith(mockData);
     }
   });

--- a/backend/src/usecase/user/command/update.test.ts
+++ b/backend/src/usecase/user/command/update.test.ts
@@ -55,38 +55,18 @@ describe("UserUpdateCommandImpl", () => {
       mockRole
     )._unsafeUnwrap();
 
-    mockAccountRepository.findById.mockResolvedValue(ok(mockData));
     mockAccountRepository.findByUserId.mockResolvedValue(err(new UnExistAccountError()));
     mockPasswordHash.hash.mockResolvedValue(mockHashedPassword);
     mockAccountRepository.save.mockResolvedValue(ok(mockNewData));
 
-    const result = await userUpdateCommand.execute(mockId, mockUserId, mockName, mockPassword);
+    const result = await userUpdateCommand.execute(mockData, mockUserId, mockName, mockPassword);
 
     expect(result.isOk()).toBe(true);
     if (result.isOk()) {
       const account = result.value;
       expect(account).toEqual(mockNewData);
-      expect(mockAccountRepository.findById).toHaveBeenCalledWith(mockId);
       expect(mockAccountRepository.findByUserId).toHaveBeenCalledWith(mockUserId);
       expect(mockAccountRepository.save).toHaveBeenCalledWith(mockNewData);
-    }
-  });
-
-  it("ユーザーが存在しない場合", async () => {
-    const userUpdateCommand = new UserUpdateCommandImpl(mockAccountRepository, mockPasswordHash);
-
-    const mockId = "mock-uuid-123";
-    const mockUserId = "new-mock-user-id";
-    const mockName = "new-mock-name";
-    const mockPassword = "new-password";
-
-    mockAccountRepository.findById.mockResolvedValue(err(new UnExistAccountError()));
-
-    const result = await userUpdateCommand.execute(mockId, mockUserId, mockName, mockPassword);
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error).toBeInstanceOf(UnExistAccountError);
     }
   });
 
@@ -96,18 +76,6 @@ describe("UserUpdateCommandImpl", () => {
     const mockId = "mock-uuid-123";
     const mockUserId = "mock-user-id";
 
-    mockAccountRepository.findById.mockResolvedValue(
-      ok(
-        Account.create(
-          mockId,
-          mockUserId,
-          "テストユーザー",
-          "hashed-password",
-          "mock-organization-id",
-          "Operator"
-        )._unsafeUnwrap()
-      )
-    );
     mockAccountRepository.findByUserId.mockResolvedValue(
       ok(
         Account.create(
@@ -122,7 +90,14 @@ describe("UserUpdateCommandImpl", () => {
     );
 
     const result = await userUpdateCommand.execute(
-      mockId,
+      Account.create(
+        mockId,
+        mockUserId,
+        "テストユーザー",
+        "hashed-password",
+        "mock-organization-id",
+        "Operator"
+      )._unsafeUnwrap(),
       mockUserId,
       "new-mock-name",
       "new-password"
@@ -131,7 +106,6 @@ describe("UserUpdateCommandImpl", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(DuplicateUserIdError);
-      expect(mockAccountRepository.findById).toHaveBeenCalledWith(mockId);
       expect(mockAccountRepository.findByUserId).toHaveBeenCalledWith(mockUserId);
     }
   });
@@ -166,17 +140,15 @@ describe("UserUpdateCommandImpl", () => {
       mockRole
     )._unsafeUnwrap();
 
-    mockAccountRepository.findById.mockResolvedValue(ok(mockData));
     mockAccountRepository.findByUserId.mockResolvedValue(err(new UnExistAccountError()));
     mockPasswordHash.hash.mockResolvedValue(mockHashedPassword);
     mockAccountRepository.save.mockResolvedValue(err(new UnexpectedError()));
 
-    const result = await userUpdateCommand.execute(mockId, mockUserId, mockName, mockPassword);
+    const result = await userUpdateCommand.execute(mockData, mockUserId, mockName, mockPassword);
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(UnexpectedError);
-      expect(mockAccountRepository.findById).toHaveBeenCalledWith(mockId);
       expect(mockAccountRepository.findByUserId).toHaveBeenCalledWith(mockUserId);
       expect(mockAccountRepository.save).toHaveBeenCalledWith(mockNewData);
     }

--- a/backend/src/usecase/user/command/update.test.ts
+++ b/backend/src/usecase/user/command/update.test.ts
@@ -1,0 +1,184 @@
+import { Account } from "@/domain/account/account.js";
+import { DuplicateUserIdError, UnExistAccountError, UnexpectedError } from "@/errors/errors.js";
+import { err, ok } from "neverthrow";
+import { describe, expect, it, vi } from "vitest";
+import { UserUpdateCommandImpl } from "./update.js";
+
+const mockAccountRepository = {
+  findById: vi.fn(),
+  findByUserId: vi.fn(),
+  save: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock("@/domain/account/account-repository.js", () => ({
+  AccountRepository: vi.fn(() => mockAccountRepository),
+}));
+
+const mockPasswordHash = {
+  hash: vi.fn(),
+  compare: vi.fn(),
+};
+
+vi.mock("@/domain/account/password-hash.js", () => ({
+  PasswordHash: vi.fn(() => mockPasswordHash),
+}));
+
+describe("UserUpdateCommandImpl", () => {
+  it("正常にユーザーを更新", async () => {
+    const userUpdateCommand = new UserUpdateCommandImpl(mockAccountRepository, mockPasswordHash);
+
+    const mockId = "mock-uuid-123";
+    const mockOrganizationId = "mock-organization-id";
+    const mockRole = "Operator";
+
+    const mockUserId = "new-mock-user-id";
+    const mockName = "new-mock-name";
+    const mockPassword = "new-password";
+    const mockHashedPassword = "new-hashed-password";
+
+    const mockData = Account.create(
+      mockId,
+      "mock-user-id",
+      "テストユーザー",
+      "hashed-password",
+      mockOrganizationId,
+      mockRole
+    )._unsafeUnwrap();
+
+    const mockNewData = Account.create(
+      mockId,
+      mockUserId,
+      mockName,
+      mockHashedPassword,
+      mockOrganizationId,
+      mockRole
+    )._unsafeUnwrap();
+
+    mockAccountRepository.findById.mockResolvedValue(ok(mockData));
+    mockAccountRepository.findByUserId.mockResolvedValue(err(new UnExistAccountError()));
+    mockPasswordHash.hash.mockResolvedValue(mockHashedPassword);
+    mockAccountRepository.save.mockResolvedValue(ok(mockNewData));
+
+    const result = await userUpdateCommand.execute(mockId, mockUserId, mockName, mockPassword);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const account = result.value;
+      expect(account).toEqual(mockNewData);
+      expect(mockAccountRepository.findById).toHaveBeenCalledWith(mockId);
+      expect(mockAccountRepository.findByUserId).toHaveBeenCalledWith(mockUserId);
+      expect(mockAccountRepository.save).toHaveBeenCalledWith(mockNewData);
+    }
+  });
+
+  it("ユーザーが存在しない場合", async () => {
+    const userUpdateCommand = new UserUpdateCommandImpl(mockAccountRepository, mockPasswordHash);
+
+    const mockId = "mock-uuid-123";
+    const mockUserId = "new-mock-user-id";
+    const mockName = "new-mock-name";
+    const mockPassword = "new-password";
+
+    mockAccountRepository.findById.mockResolvedValue(err(new UnExistAccountError()));
+
+    const result = await userUpdateCommand.execute(mockId, mockUserId, mockName, mockPassword);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(UnExistAccountError);
+    }
+  });
+
+  it("ユーザーIDが重複している場合", async () => {
+    const userUpdateCommand = new UserUpdateCommandImpl(mockAccountRepository, mockPasswordHash);
+
+    const mockId = "mock-uuid-123";
+    const mockUserId = "mock-user-id";
+
+    mockAccountRepository.findById.mockResolvedValue(
+      ok(
+        Account.create(
+          mockId,
+          mockUserId,
+          "テストユーザー",
+          "hashed-password",
+          "mock-organization-id",
+          "Operator"
+        )._unsafeUnwrap()
+      )
+    );
+    mockAccountRepository.findByUserId.mockResolvedValue(
+      ok(
+        Account.create(
+          "mock-uuid-456",
+          mockUserId,
+          "テストユーザー2",
+          "hashed-password-2",
+          "mock-organization-id-2",
+          "Operator"
+        )._unsafeUnwrap()
+      )
+    );
+
+    const result = await userUpdateCommand.execute(
+      mockId,
+      mockUserId,
+      "new-mock-name",
+      "new-password"
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(DuplicateUserIdError);
+      expect(mockAccountRepository.findById).toHaveBeenCalledWith(mockId);
+      expect(mockAccountRepository.findByUserId).toHaveBeenCalledWith(mockUserId);
+    }
+  });
+
+  it("データベースエラー", async () => {
+    const userUpdateCommand = new UserUpdateCommandImpl(mockAccountRepository, mockPasswordHash);
+
+    const mockId = "mock-uuid-123";
+    const mockOrganizationId = "mock-organization-id";
+    const mockRole = "Operator";
+
+    const mockUserId = "new-mock-user-id";
+    const mockName = "new-mock-name";
+    const mockPassword = "new-password";
+    const mockHashedPassword = "new-hashed-password";
+
+    const mockData = Account.create(
+      mockId,
+      "mock-user-id",
+      "テストユーザー",
+      "hashed-password",
+      mockOrganizationId,
+      mockRole
+    )._unsafeUnwrap();
+
+    const mockNewData = Account.create(
+      mockId,
+      mockUserId,
+      mockName,
+      mockHashedPassword,
+      mockOrganizationId,
+      mockRole
+    )._unsafeUnwrap();
+
+    mockAccountRepository.findById.mockResolvedValue(ok(mockData));
+    mockAccountRepository.findByUserId.mockResolvedValue(err(new UnExistAccountError()));
+    mockPasswordHash.hash.mockResolvedValue(mockHashedPassword);
+    mockAccountRepository.save.mockResolvedValue(err(new UnexpectedError()));
+
+    const result = await userUpdateCommand.execute(mockId, mockUserId, mockName, mockPassword);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(UnexpectedError);
+      expect(mockAccountRepository.findById).toHaveBeenCalledWith(mockId);
+      expect(mockAccountRepository.findByUserId).toHaveBeenCalledWith(mockUserId);
+      expect(mockAccountRepository.save).toHaveBeenCalledWith(mockNewData);
+    }
+  });
+});

--- a/backend/src/usecase/user/command/update.ts
+++ b/backend/src/usecase/user/command/update.ts
@@ -8,7 +8,7 @@ import type { Result } from "neverthrow";
 
 export interface UserUpdateCommand {
   execute(
-    id: string,
+    account: Account,
     userId: string | undefined,
     name: string | undefined,
     password: string | undefined
@@ -22,17 +22,11 @@ export class UserUpdateCommandImpl implements UserUpdateCommand {
   ) {}
 
   async execute(
-    id: string,
+    account: Account,
     userId: string | undefined,
     name: string | undefined,
     password: string | undefined
   ): Promise<Result<Account, AppError>> {
-    const account = await this.accountRepository.findById(id);
-
-    if (account.isErr()) {
-      return err(account.error);
-    }
-
     if (userId) {
       const userIdExist = await this.accountRepository.findByUserId(userId);
       if (userIdExist.isErr() && !(userIdExist.error instanceof UnExistAccountError)) {
@@ -45,7 +39,7 @@ export class UserUpdateCommandImpl implements UserUpdateCommand {
 
     const hashedPassword = password ? await this.passwordHash.hash(password) : undefined;
 
-    const updatedAccount = account.value.update(userId, name, hashedPassword, undefined, undefined);
+    const updatedAccount = account.update(userId, name, hashedPassword, undefined, undefined);
 
     if (updatedAccount.isErr()) {
       return err(new UnexpectedError(updatedAccount.error.message));

--- a/backend/src/usecase/user/command/update.ts
+++ b/backend/src/usecase/user/command/update.ts
@@ -1,0 +1,62 @@
+import type { AccountRepository } from "@/domain/account/account-repository.js";
+import type { Account } from "@/domain/account/account.js";
+import type { PasswordHash } from "@/domain/account/password-hash.js";
+import { DuplicateUserIdError, UnExistAccountError, UnexpectedError } from "@/errors/errors.js";
+import type { AppError } from "@/errors/errors.js";
+import { err, ok } from "neverthrow";
+import type { Result } from "neverthrow";
+
+export interface UserUpdateCommand {
+  execute(
+    id: string,
+    userId: string | undefined,
+    name: string | undefined,
+    password: string | undefined
+  ): Promise<Result<Account, AppError>>;
+}
+
+export class UserUpdateCommandImpl implements UserUpdateCommand {
+  constructor(
+    private readonly accountRepository: AccountRepository,
+    private readonly passwordHash: PasswordHash
+  ) {}
+
+  async execute(
+    id: string,
+    userId: string | undefined,
+    name: string | undefined,
+    password: string | undefined
+  ): Promise<Result<Account, AppError>> {
+    const account = await this.accountRepository.findById(id);
+
+    if (account.isErr()) {
+      return err(account.error);
+    }
+
+    if (userId) {
+      const userIdExist = await this.accountRepository.findByUserId(userId);
+      if (userIdExist.isErr() && !(userIdExist.error instanceof UnExistAccountError)) {
+        return err(userIdExist.error);
+      }
+      if (userIdExist.isOk()) {
+        return err(new DuplicateUserIdError());
+      }
+    }
+
+    const hashedPassword = password ? await this.passwordHash.hash(password) : undefined;
+
+    const updatedAccount = account.value.update(userId, name, hashedPassword, undefined, undefined);
+
+    if (updatedAccount.isErr()) {
+      return err(new UnexpectedError(updatedAccount.error.message));
+    }
+
+    const result = await this.accountRepository.save(updatedAccount.value);
+
+    if (result.isErr()) {
+      return err(new UnexpectedError(result.error.message));
+    }
+
+    return ok(result.value);
+  }
+}

--- a/schema/src/user.tsp
+++ b/schema/src/user.tsp
@@ -10,6 +10,12 @@ model CreateUserRequest {
   role: Role;
 }
 
+model UpdateUserRequest {
+  userId: string;
+  name: string;
+  password: string;
+}
+
 model UpdateUserRoleRequest {
   role: Role;
 }
@@ -23,6 +29,21 @@ interface UserAPI {
     | {
         @statusCode
         statusCode: 201;
+
+        @body
+        account: Account;
+      }
+    | BadRequestError
+    | ForbiddenError
+    | InternalServerError;
+
+  @put
+  @route("/user/{id}")
+  @summary("ユーザープロファイルの更新")
+  update(@path id: string, @body body: UpdateUserRequest):
+    | {
+        @statusCode
+        statusCode: 200;
 
         @body
         account: Account;


### PR DESCRIPTION
## 関連Issue

<!-- 例: Closes #12 -->
Closes #58 

## 概要

<!-- このPRの目的や背景を簡潔に記載 -->
ユーザープロファイルを更新するAPIを実装しました。

SuperAdmin ->全てのユーザーの情報を変更可能
Manager/Operator ->自分のプロファイルのみ変更可能

## 変更内容

<!-- 主な変更点や実装内容を箇条書きで記載 -->
- スキーマを定義しました。
- `UserUpdateCommand`のテスト及び実装を行いました。
- presentation層及び認可ミドルウェアを実装しました。

## 確認事項

- [ ] ローカルで動作確認済み
<!-- - [ ] 必要に応じてスクリーンショットを添付した -->

## 備考

<!-- レビュー時に共有しておきたいことがあれば記載 -->
