### PR TITLE
フロントエンド・ユーザーロール更新機能

### DIFF
--- a/backend/src/presentation/middleware/permission.ts
+++ b/backend/src/presentation/middleware/permission.ts
@@ -31,7 +31,7 @@ const permissionPolicy = (actor: Account, action: Action, resource: Resource): b
   if (resource.type === "Organization") {
     switch (action) {
       case "read":
-        if (actor.role === "Manager" && actor.organizationId === resource.content) {
+        if (actor.organizationId === resource.content) {
           return true;
         }
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-navigation-menu": "^1.2.13",
+    "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-query": "^5.81.5",

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,167 @@
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/frontend/src/features/organization/dialog/create-user-dialog.tsx
+++ b/frontend/src/features/organization/dialog/create-user-dialog.tsx
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useAuthStore } from "@/store/auth-store";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
@@ -48,6 +49,8 @@ export const OrganizationCreateUserDialog = ({
   setIsOpenCreateUserDialog: (isOpen: boolean) => void;
   organizationId: string;
 }) => {
+  const { account } = useAuthStore.getState();
+
   const queryClient = useQueryClient();
   const mutation = useMutation({
     ...userApiCreateMutation(),
@@ -145,7 +148,9 @@ export const OrganizationCreateUserDialog = ({
             <SelectContent>
               <SelectGroup>
                 <SelectLabel>ロール</SelectLabel>
-                <SelectItem value="SuperAdmin">SuperAdmin</SelectItem>
+                {account?.role === "SuperAdmin" && (
+                  <SelectItem value="SuperAdmin">SuperAdmin</SelectItem>
+                )}
                 <SelectItem value="Manager">Manager</SelectItem>
                 <SelectItem value="Operator">Operator</SelectItem>
               </SelectGroup>

--- a/frontend/src/features/organization/dialog/create-user-dialog.tsx
+++ b/frontend/src/features/organization/dialog/create-user-dialog.tsx
@@ -1,0 +1,165 @@
+import {
+  organizationApiGetOptions,
+  userApiCreateMutation,
+} from "@/client/@tanstack/react-query.gen";
+import type { zCreateUserRequest } from "@/client/zod.gen";
+import { Button } from "@/components/ui/button";
+import { DialogClose, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { DialogFooter } from "@/components/ui/dialog";
+import { DialogForm } from "@/components/ui/dialog-form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { Controller } from "react-hook-form";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+const formSchema = z.object({
+  userId: z.string().min(1, {
+    message: "ユーザーIDを入力してください。",
+  }),
+  name: z.string().min(1, {
+    message: "ユーザー名を入力してください。",
+  }),
+  password: z.string().min(1, {
+    message: "パスワードを入力してください。",
+  }),
+  organizationId: z.string().optional(),
+  role: z.enum(["SuperAdmin", "Manager", "Operator"]),
+});
+
+export const OrganizationCreateUserDialog = ({
+  isOpenCreateUserDialog,
+  setIsOpenCreateUserDialog,
+  organizationId,
+}: {
+  isOpenCreateUserDialog: boolean;
+  setIsOpenCreateUserDialog: (isOpen: boolean) => void;
+  organizationId: string;
+}) => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    ...userApiCreateMutation(),
+    onSuccess: (data) => {
+      toast.success(`「${data.name}」を作成しました`, { duration: 1000 });
+      queryClient.refetchQueries({
+        queryKey: organizationApiGetOptions({
+          path: {
+            id: organizationId,
+          },
+        }).queryKey,
+      });
+    },
+    onError: (error) => {
+      toast.error(
+        error.message === "Conflict"
+          ? "使用できないユーザーIDです"
+          : error.message || "エラーが発生しました",
+        { duration: 1000 }
+      );
+    },
+  });
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<z.infer<typeof zCreateUserRequest>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      userId: "",
+      name: "",
+      password: "",
+      organizationId: organizationId,
+      role: undefined,
+    },
+  });
+
+  const onSubmit: SubmitHandler<z.infer<typeof zCreateUserRequest>> = async (data) => {
+    await mutation.mutateAsync({
+      body: data,
+    });
+    setIsOpenCreateUserDialog(false);
+    reset();
+  };
+
+  return (
+    <DialogForm
+      open={isOpenCreateUserDialog}
+      onOpenChange={(open) => {
+        setIsOpenCreateUserDialog(open);
+        reset();
+      }}
+      formProps={{
+        onSubmit: handleSubmit(onSubmit),
+      }}
+    >
+      <DialogHeader>
+        <DialogTitle>ユーザーを新規作成</DialogTitle>
+        <DialogDescription>新しく作成するユーザーの情報を設定してください。</DialogDescription>
+      </DialogHeader>
+      <Controller
+        control={control}
+        name="userId"
+        render={({ field }) => (
+          <Input type="text" placeholder="ユーザーIDを入力してください" {...field} />
+        )}
+      />
+      {errors.userId?.message && <p className="text-red-700">{errors.userId.message}</p>}
+      <Controller
+        control={control}
+        name="name"
+        render={({ field }) => (
+          <Input type="text" placeholder="ユーザー名を入力してください" {...field} />
+        )}
+      />
+      {errors.name?.message && <p className="text-red-700">{errors.name.message}</p>}
+      <Controller
+        control={control}
+        name="password"
+        render={({ field }) => (
+          <Input type="password" placeholder="パスワードを入力してください" {...field} />
+        )}
+      />
+      {errors.password?.message && <p className="text-red-700">{errors.password.message}</p>}
+      <Controller
+        control={control}
+        name="role"
+        render={({ field }) => (
+          <Select onValueChange={field.onChange} value={field.value}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="ロールを選択してください" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>ロール</SelectLabel>
+                <SelectItem value="SuperAdmin">SuperAdmin</SelectItem>
+                <SelectItem value="Manager">Manager</SelectItem>
+                <SelectItem value="Operator">Operator</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        )}
+      />
+      {errors.role?.message && <p className="text-red-700">{errors.role.message}</p>}
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant={"outline"}>キャンセル</Button>
+        </DialogClose>
+        <Button type="submit">作成する</Button>
+      </DialogFooter>
+    </DialogForm>
+  );
+};

--- a/frontend/src/features/organization/dialog/create-user-dialog.tsx
+++ b/frontend/src/features/organization/dialog/create-user-dialog.tsx
@@ -28,16 +28,18 @@ import { z } from "zod";
 
 const formSchema = z.object({
   userId: z.string().min(1, {
-    message: "ユーザーIDを入力してください。",
+    message: "ユーザーIDを入力してください",
   }),
   name: z.string().min(1, {
-    message: "ユーザー名を入力してください。",
+    message: "ユーザー名を入力してください",
   }),
   password: z.string().min(1, {
-    message: "パスワードを入力してください。",
+    message: "パスワードを入力してください",
   }),
   organizationId: z.string().optional(),
-  role: z.enum(["SuperAdmin", "Manager", "Operator"]),
+  role: z.enum(["SuperAdmin", "Manager", "Operator"], {
+    required_error: "ロールを選択してください",
+  }),
 });
 
 export const OrganizationCreateUserDialog = ({

--- a/frontend/src/features/organization/dialog/update-user-dialog.tsx
+++ b/frontend/src/features/organization/dialog/update-user-dialog.tsx
@@ -1,0 +1,142 @@
+import type { Account as UserType } from "@/client";
+import {
+  organizationApiGetOptions,
+  userApiUpdateRoleMutation,
+} from "@/client/@tanstack/react-query.gen";
+import type { zUpdateUserRoleRequest } from "@/client/zod.gen";
+import { Button } from "@/components/ui/button";
+import {
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { DialogForm } from "@/components/ui/dialog-form";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAuthStore } from "@/store/auth-store";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Controller, type SubmitHandler, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+const formSchema = z.object({
+  role: z.enum(["SuperAdmin", "Manager", "Operator"], {
+    required_error: "ロールを選択してください",
+  }),
+});
+
+export const OrganizationUpdateUserDialog = ({
+  isOpenUpdateUserDialog,
+  setIsOpenUpdateUserDialog,
+  organizationId,
+  user,
+  setSelectedUser,
+}: {
+  isOpenUpdateUserDialog: boolean;
+  setIsOpenUpdateUserDialog: (isOpenUpdateUserDialog: boolean) => void;
+  organizationId: string;
+  user: UserType;
+  setSelectedUser: (user: UserType | undefined) => void;
+}) => {
+  const { account } = useAuthStore.getState();
+
+  const queryClient = useQueryClient();
+
+  const resetDialogState = () => {
+    setIsOpenUpdateUserDialog(false);
+    setSelectedUser(undefined);
+  };
+
+  const mutation = useMutation({
+    ...userApiUpdateRoleMutation(),
+    onSuccess: (data) => {
+      toast.success(`「${data.name}」のロールを更新しました`, { duration: 1000 });
+      queryClient.refetchQueries({
+        queryKey: organizationApiGetOptions({
+          path: {
+            id: organizationId,
+          },
+        }).queryKey,
+      });
+    },
+    onError: (error) => {
+      toast.error(error.message || "エラーが発生しました", { duration: 1000 });
+    },
+  });
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<z.infer<typeof zUpdateUserRoleRequest>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      role: user.role,
+    },
+  });
+
+  const onSubmit: SubmitHandler<z.infer<typeof zUpdateUserRoleRequest>> = async (data) => {
+    await mutation.mutateAsync({
+      body: data,
+      path: {
+        id: user.id,
+      },
+    });
+    resetDialogState();
+    reset();
+  };
+
+  return (
+    <DialogForm
+      open={isOpenUpdateUserDialog}
+      onOpenChange={resetDialogState}
+      formProps={{
+        onSubmit: handleSubmit(onSubmit),
+      }}
+    >
+      <DialogHeader>
+        <DialogTitle>ユーザーを編集</DialogTitle>
+        <DialogDescription>ユーザーのロールを変更できます。</DialogDescription>
+      </DialogHeader>
+      <Controller
+        control={control}
+        name="role"
+        render={({ field }) => (
+          <Select onValueChange={field.onChange} value={field.value}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="ロールを選択してください" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>ロール</SelectLabel>
+                {account?.role === "SuperAdmin" && (
+                  <SelectItem value="SuperAdmin">SuperAdmin</SelectItem>
+                )}
+                <SelectItem value="Manager">Manager</SelectItem>
+                <SelectItem value="Operator">Operator</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        )}
+      />
+      {errors.role?.message && <p className="text-red-700">{errors.role.message}</p>}
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant={"outline"}>キャンセル</Button>
+        </DialogClose>
+        <Button type="submit">更新する</Button>
+      </DialogFooter>
+    </DialogForm>
+  );
+};

--- a/frontend/src/features/organization/profile.tsx
+++ b/frontend/src/features/organization/profile.tsx
@@ -8,6 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useAuthStore } from "@/store/auth-store";
 import { useState } from "react";
 import { OrganizationCreateUserDialog } from "./dialog/create-user-dialog";
 
@@ -15,6 +16,7 @@ export const OrganizationProfile = ({
   organization,
 }: { organization: OrganizationProfileType }) => {
   const [isOpenCreateUserDialog, setIsOpenCreateUserDialog] = useState<boolean>(false);
+  const { account } = useAuthStore.getState();
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50 p-6">
       <div className="max-w-6xl mx-auto">
@@ -22,15 +24,17 @@ export const OrganizationProfile = ({
           <h1 className="text-3xl font-bold text-gray-900 mb-2">{organization.name}</h1>
           <p className="text-gray-600">登録されているユーザー</p>
         </div>
-        <div className="w-full flex justify-end mb-2">
-          <Button
-            onClick={() => {
-              setIsOpenCreateUserDialog(true);
-            }}
-          >
-            新規ユーザー作成
-          </Button>
-        </div>
+        {(account?.role === "SuperAdmin" || account?.role === "Manager") && (
+          <div className="w-full flex justify-end mb-2">
+            <Button
+              onClick={() => {
+                setIsOpenCreateUserDialog(true);
+              }}
+            >
+              新規ユーザー作成
+            </Button>
+          </div>
+        )}
         <div className="bg-white rounded-lg shadow-sm border">
           <div className="p-4 border-b">
             <h2 className="text-l font-semibold text-gray-900">ユーザー</h2>

--- a/frontend/src/features/organization/profile.tsx
+++ b/frontend/src/features/organization/profile.tsx
@@ -1,4 +1,5 @@
 import type { OrganizationProfile as OrganizationProfileType } from "@/client";
+import type { Account as UserType } from "@/client";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -8,14 +9,19 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAuthStore } from "@/store/auth-store";
+import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { OrganizationCreateUserDialog } from "./dialog/create-user-dialog";
+import { OrganizationUpdateUserDialog } from "./dialog/update-user-dialog";
 
 export const OrganizationProfile = ({
   organization,
 }: { organization: OrganizationProfileType }) => {
   const [isOpenCreateUserDialog, setIsOpenCreateUserDialog] = useState<boolean>(false);
+  const [isOpenUpdateUserDialog, setIsOpenUpdateUserDialog] = useState<boolean>(false);
+  const [selectedUser, setSelectedUser] = useState<UserType | undefined>(undefined);
   const { account } = useAuthStore.getState();
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50 p-6">
@@ -44,6 +50,8 @@ export const OrganizationProfile = ({
               <TableRow>
                 <TableHead className="w-[80px]">ID</TableHead>
                 <TableHead>名前</TableHead>
+                <TableHead className="w-[100px]">ロール</TableHead>
+                <TableHead className="w-[120px]"> </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -51,6 +59,28 @@ export const OrganizationProfile = ({
                 <TableRow key={user.id}>
                   <TableCell className="font-medium">{user.userId}</TableCell>
                   <TableCell className="font-medium">{user.name}</TableCell>
+                  <TableCell className="font-medium">{user.role}</TableCell>{" "}
+                  <TableCell className="flex justify-center items-center">
+                    {(account?.role === "SuperAdmin" ||
+                      (account?.role === "Manager" && user.role !== "SuperAdmin")) && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Pencil
+                            size={20}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setIsOpenUpdateUserDialog(true);
+                              setSelectedUser(user);
+                            }}
+                            className="text-gray-600 hover:text-gray-900 mr-6 cursor-pointer"
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>編集</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -62,6 +92,15 @@ export const OrganizationProfile = ({
         setIsOpenCreateUserDialog={setIsOpenCreateUserDialog}
         organizationId={organization.id}
       />
+      {!!selectedUser && (
+        <OrganizationUpdateUserDialog
+          isOpenUpdateUserDialog={isOpenUpdateUserDialog}
+          setIsOpenUpdateUserDialog={setIsOpenUpdateUserDialog}
+          organizationId={organization.id}
+          user={selectedUser}
+          setSelectedUser={setSelectedUser}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/features/organization/profile.tsx
+++ b/frontend/src/features/organization/profile.tsx
@@ -1,4 +1,5 @@
 import type { OrganizationProfile as OrganizationProfileType } from "@/client";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -7,16 +8,28 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { useState } from "react";
+import { OrganizationCreateUserDialog } from "./dialog/create-user-dialog";
 
 export const OrganizationProfile = ({
   organization,
 }: { organization: OrganizationProfileType }) => {
+  const [isOpenCreateUserDialog, setIsOpenCreateUserDialog] = useState<boolean>(false);
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50 p-6">
       <div className="max-w-6xl mx-auto">
         <div className="mb-2">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">{organization.name}</h1>
           <p className="text-gray-600">登録されているユーザー</p>
+        </div>
+        <div className="w-full flex justify-end mb-2">
+          <Button
+            onClick={() => {
+              setIsOpenCreateUserDialog(true);
+            }}
+          >
+            新規ユーザー作成
+          </Button>
         </div>
         <div className="bg-white rounded-lg shadow-sm border">
           <div className="p-4 border-b">
@@ -40,6 +53,11 @@ export const OrganizationProfile = ({
           </Table>
         </div>
       </div>
+      <OrganizationCreateUserDialog
+        isOpenCreateUserDialog={isOpenCreateUserDialog}
+        setIsOpenCreateUserDialog={setIsOpenCreateUserDialog}
+        organizationId={organization.id}
+      />
     </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@radix-ui/react-navigation-menu':
         specifier: ^1.2.13
         version: 1.2.13(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select':
+        specifier: ^2.2.5
+        version: 2.2.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@18.3.23)(react@18.3.1)
@@ -1273,6 +1276,9 @@ packages:
   '@prisma/get-platform@6.11.1':
     resolution: {integrity: sha512-b2Z8oV2gwvdCkFemBTFd0x4lsL4O2jLSx8lB7D+XqoFALOQZPa7eAPE1NU0Mj1V8gPHRxIsHnyUNtw2i92psUw==}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
@@ -1453,6 +1459,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.5':
+    resolution: {integrity: sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5632,6 +5651,8 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.11.1
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.2': {}
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -5806,6 +5827,35 @@ snapshots:
       '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
+  '@radix-ui/react-select@2.2.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.1(@types/react@18.3.23)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)


### PR DESCRIPTION
## 関連Issue

<!-- 例: Closes #12 -->
Closes #48 

## 概要

<!-- このPRの目的や背景を簡潔に記載 -->
ユーザーロールを更新するフロントエンド機能を追加しました。

## 変更内容

<!-- 主な変更点や実装内容を箇条書きで記載 -->
- 組織詳細画面にユーザーロールも表示に追加しました。
  - APIの変更、必要なし。
- 組織詳細画面のユーザーに編集ボタンを追加しました。
- ユーザーロール更新ダイアログを実装しました。
- ロールによる制御を実装しました。
  - SuperAdminには編集ボタン表示、及び選択できるロールに制限なし。
  - ManagerはSuperAdmin以外のユーザーの編集ボタンを表示、及び選択できるロールを「Manager」「Operator」に制限。
  - Operatorにはユーザー編集ボタンの表示なし。

## 確認事項

- [ ] ローカルで動作確認済み
<!-- - [ ] 必要に応じてスクリーンショットを添付した -->

## 備考

<!-- レビュー時に共有しておきたいことがあれば記載 -->
