### PR TITLE
フロントエンド・ユーザー削除機能

### DIFF
--- a/frontend/src/features/organization/dialog/delete-user-dialog.tsx
+++ b/frontend/src/features/organization/dialog/delete-user-dialog.tsx
@@ -1,0 +1,89 @@
+import type { Account as UserType } from "@/client";
+import {
+  organizationApiGetListOptions,
+  organizationApiGetOptions,
+  userApiDeleteMutation,
+} from "@/client/@tanstack/react-query.gen";
+import { Button } from "@/components/ui/button";
+import {
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { DialogForm } from "@/components/ui/dialog-form";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { type SubmitHandler, useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+export const UserDeleteDialog = ({
+  isOpenDeleteUserDialog,
+  setIsOpenDeleteUserDialog,
+  organizationId,
+  user,
+  setSelectedUser,
+}: {
+  isOpenDeleteUserDialog: boolean;
+  setIsOpenDeleteUserDialog: (isOpenDeleteUserDialog: boolean) => void;
+  organizationId: string;
+  user: UserType;
+  setSelectedUser: (user: UserType | undefined) => void;
+}) => {
+  const queryClient = useQueryClient();
+
+  const resetDialogState = () => {
+    setIsOpenDeleteUserDialog(false);
+    setSelectedUser(undefined);
+  };
+
+  const mutation = useMutation({
+    ...userApiDeleteMutation(),
+    onSuccess: () => {
+      toast.success(`「${user.name}」を削除しました`, { duration: 1000 });
+      queryClient.refetchQueries({
+        queryKey: organizationApiGetOptions({
+          path: {
+            id: organizationId,
+          },
+        }).queryKey,
+      });
+      resetDialogState();
+    },
+    onError: (error) => {
+      toast.error(error.message || "エラーが発生しました", { duration: 500 });
+      resetDialogState();
+    },
+  });
+
+  const { handleSubmit } = useForm<never>();
+
+  const onSubmit: SubmitHandler<never> = async () => {
+    await mutation.mutateAsync({
+      path: {
+        id: user.id,
+      },
+    });
+  };
+
+  return (
+    <DialogForm
+      open={isOpenDeleteUserDialog}
+      onOpenChange={resetDialogState}
+      formProps={{
+        onSubmit: handleSubmit(onSubmit),
+      }}
+    >
+      <DialogHeader>
+        <DialogTitle>「{user.name}」を削除します</DialogTitle>
+        <DialogDescription>この操作は元に戻せません。</DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant={"outline"}>キャンセル</Button>
+        </DialogClose>
+        <Button type="submit">削除する</Button>
+      </DialogFooter>
+    </DialogForm>
+  );
+};

--- a/frontend/src/features/organization/dialog/delete-user-dialog.tsx
+++ b/frontend/src/features/organization/dialog/delete-user-dialog.tsx
@@ -1,6 +1,5 @@
 import type { Account as UserType } from "@/client";
 import {
-  organizationApiGetListOptions,
   organizationApiGetOptions,
   userApiDeleteMutation,
 } from "@/client/@tanstack/react-query.gen";

--- a/frontend/src/features/organization/profile.tsx
+++ b/frontend/src/features/organization/profile.tsx
@@ -14,6 +14,7 @@ import { useAuthStore } from "@/store/auth-store";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { UserCreateDialog } from "./dialog/create-user-dialog";
+import { UserDeleteDialog } from "./dialog/delete-user-dialog";
 import { UserUpdateDialog } from "./dialog/update-user-dialog";
 
 export const OrganizationProfile = ({
@@ -21,6 +22,7 @@ export const OrganizationProfile = ({
 }: { organization: OrganizationProfileType }) => {
   const [isOpenCreateUserDialog, setIsOpenCreateUserDialog] = useState<boolean>(false);
   const [isOpenUpdateUserDialog, setIsOpenUpdateUserDialog] = useState<boolean>(false);
+  const [isOpenDeleteUserDialog, setIsOpenDeleteUserDialog] = useState<boolean>(false);
   const [selectedUser, setSelectedUser] = useState<UserType | undefined>(undefined);
   const { account } = useAuthStore.getState();
   return (
@@ -63,22 +65,40 @@ export const OrganizationProfile = ({
                   <TableCell className="flex justify-center items-center">
                     {(account?.role === "SuperAdmin" ||
                       (account?.role === "Manager" && user.role !== "SuperAdmin")) && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Pencil
-                            size={20}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setIsOpenUpdateUserDialog(true);
-                              setSelectedUser(user);
-                            }}
-                            className="text-gray-600 hover:text-gray-900 mr-6 cursor-pointer"
-                          />
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>編集</p>
-                        </TooltipContent>
-                      </Tooltip>
+                      <>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Pencil
+                              size={20}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setIsOpenUpdateUserDialog(true);
+                                setSelectedUser(user);
+                              }}
+                              className="text-gray-600 hover:text-gray-900 mr-6 cursor-pointer"
+                            />
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>編集</p>
+                          </TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Trash2
+                              size={20}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setIsOpenDeleteUserDialog(true);
+                                setSelectedUser(user);
+                              }}
+                              className="text-gray-600 hover:text-gray-900 mr-6 cursor-pointer"
+                            />
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>削除</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </>
                     )}
                   </TableCell>
                 </TableRow>
@@ -96,6 +116,15 @@ export const OrganizationProfile = ({
         <UserUpdateDialog
           isOpenUpdateUserDialog={isOpenUpdateUserDialog}
           setIsOpenUpdateUserDialog={setIsOpenUpdateUserDialog}
+          organizationId={organization.id}
+          user={selectedUser}
+          setSelectedUser={setSelectedUser}
+        />
+      )}
+      {!!selectedUser && (
+        <UserDeleteDialog
+          isOpenDeleteUserDialog={isOpenDeleteUserDialog}
+          setIsOpenDeleteUserDialog={setIsOpenDeleteUserDialog}
           organizationId={organization.id}
           user={selectedUser}
           setSelectedUser={setSelectedUser}


### PR DESCRIPTION
## 関連Issue

<!-- 例: Closes #12 -->
Closes #57 

## 概要

<!-- このPRの目的や背景を簡潔に記載 -->
ユーザーを削除する機能をフロントエンドに追加しました。

## 変更内容

<!-- 主な変更点や実装内容を箇条書きで記載 -->
- 組織プロファイル画面に追加実装する形としました。
- ユーザーrawに削除ボタンを追加しました。
  - 権限による表示の制御は、editボタンと同じとしました。
- ユーザー削除ダイアログを作成しました。React Hook Form + mutationで、ユーザー削除APIがリクエストできるようにしました。

## 確認事項

- [ ] ローカルで動作確認済み
<!-- - [ ] 必要に応じてスクリーンショットを添付した -->
<img width="1352" height="865" alt="スクリーンショット 2025-07-24 16 08 56" src="https://github.com/user-attachments/assets/cb264826-39d7-46f7-9cd0-5cd8b721294d" />

## 備考

<!-- レビュー時に共有しておきたいことがあれば記載 -->
