### PR TITLE
フロントエンド・Todoリストの表示

### DIFF
--- a/backend/prisma/models/organization.prisma
+++ b/backend/prisma/models/organization.prisma
@@ -5,6 +5,7 @@ model Organization {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   accounts Account[]
+  todos    Todo[]
 
   @@map("organizations")
 }

--- a/backend/prisma/models/todo.prisma
+++ b/backend/prisma/models/todo.prisma
@@ -1,0 +1,19 @@
+enum TodoStatus {
+  NotStarted
+  InProgress
+  Completed
+}
+
+model Todo {
+  id             String     @id @default(uuid()) @db.Uuid
+  title          String     @db.VarChar(255)
+  description    String     @db.Text
+  organizationId String     @map("organization_id") @db.Uuid
+  status         TodoStatus
+  createdAt      DateTime   @default(now()) @map("created_at")
+  updatedAt      DateTime   @updatedAt @map("updated_at")
+
+  organization Organization @relation(fields: [organizationId], references: [id])
+
+  @@map("todos")
+}

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -49,7 +49,7 @@ async function main() {
   const createAccountPermissionId = uuidv4();
   const updateAccountPermissionId = uuidv4();
   const deleteAccountPermissionId = uuidv4();
-
+  const readTodoPermissionId = uuidv4();
   const readOrganizationPermission = await prisma.permission.upsert({
     where: { name: "read:Organization" },
     update: {},
@@ -122,6 +122,14 @@ async function main() {
       name: "delete:Account",
     },
   });
+  const readTodoPermission = await prisma.permission.upsert({
+    where: { name: "read:Todo" },
+    update: {},
+    create: {
+      id: readTodoPermissionId,
+      name: "read:Todo",
+    },
+  });
   console.log({
     readOrganizationPermission,
     readAllOrganizationPermission,
@@ -132,6 +140,7 @@ async function main() {
     createAccountPermission,
     updateAccountPermission,
     deleteAccountPermission,
+    readTodoPermission,
   });
 
   const superAdminRoleReadOrganizationPermission = await prisma.rolePermission.upsert({
@@ -251,6 +260,31 @@ async function main() {
       permissionId: deleteAccountPermission.id,
     },
   });
+  const superAdminRoleReadTodoPermission = await prisma.rolePermission.upsert({
+    where: {
+      roleId_permissionId: {
+        roleId: superAdminRole.id,
+        permissionId: readTodoPermission.id,
+      },
+    },
+    update: {},
+    create: {
+      roleId: superAdminRole.id,
+      permissionId: readTodoPermission.id,
+    },
+  });
+  console.log({
+    superAdminRoleReadOrganizationPermission,
+    superAdminRoleReadAllOrganizationPermission,
+    superAdminRoleCreateOrganizationPermission,
+    superAdminRoleUpdateOrganizationPermission,
+    superAdminRoleDeleteOrganizationPermission,
+    superAdminRoleReadAccountPermission,
+    superAdminRoleCreateAccountPermission,
+    superAdminRoleUpdateAccountPermission,
+    superAdminRoleDeleteAccountPermission,
+    superAdminRoleReadTodoPermission,
+  });
   const managerRoleReadOrganizationPermission = await prisma.rolePermission.upsert({
     where: {
       roleId_permissionId: {
@@ -316,6 +350,27 @@ async function main() {
       permissionId: deleteAccountPermission.id,
     },
   });
+  const managerRoleReadTodoPermission = await prisma.rolePermission.upsert({
+    where: {
+      roleId_permissionId: {
+        roleId: managerRole.id,
+        permissionId: readTodoPermission.id,
+      },
+    },
+    update: {},
+    create: {
+      roleId: managerRole.id,
+      permissionId: readTodoPermission.id,
+    },
+  });
+  console.log({
+    managerRoleReadOrganizationPermission,
+    managerRoleReadAccountPermission,
+    managerRoleCreateAccountPermission,
+    managerRoleUpdateAccountPermission,
+    managerRoleDeleteAccountPermission,
+    managerRoleReadTodoPermission,
+  });
   const operatorRoleReadOrganizationPermission = await prisma.rolePermission.upsert({
     where: {
       roleId_permissionId: {
@@ -355,31 +410,31 @@ async function main() {
       permissionId: updateAccountPermission.id,
     },
   });
+  const operatorRoleReadTodoPermission = await prisma.rolePermission.upsert({
+    where: {
+      roleId_permissionId: {
+        roleId: operatorRole.id,
+        permissionId: readTodoPermission.id,
+      },
+    },
+    update: {},
+    create: {
+      roleId: operatorRole.id,
+      permissionId: readTodoPermission.id,
+    },
+  });
   console.log({
-    superAdminRoleReadOrganizationPermission,
-    superAdminRoleReadAllOrganizationPermission,
-    superAdminRoleCreateOrganizationPermission,
-    superAdminRoleUpdateOrganizationPermission,
-    superAdminRoleDeleteOrganizationPermission,
-    superAdminRoleReadAccountPermission,
-    superAdminRoleCreateAccountPermission,
-    superAdminRoleUpdateAccountPermission,
-    superAdminRoleDeleteAccountPermission,
-    managerRoleReadOrganizationPermission,
-    managerRoleReadAccountPermission,
-    managerRoleCreateAccountPermission,
-    managerRoleUpdateAccountPermission,
-    managerRoleDeleteAccountPermission,
     operatorRoleReadOrganizationPermission,
     operatorRoleReadAccountPermission,
     operatorRoleUpdateAccountPermission,
+    operatorRoleReadTodoPermission,
   });
 
   // Organization
   const organizationId01 = uuidv4();
   const organizationId02 = uuidv4();
   const organization01 = await prisma.organization.upsert({
-    where: { id: organizationId01 },
+    where: { name: "テスト組織01" },
     update: {},
     create: {
       id: organizationId01,
@@ -389,7 +444,7 @@ async function main() {
     },
   });
   const organization02 = await prisma.organization.upsert({
-    where: { id: organizationId02 },
+    where: { name: "テスト組織02" },
     update: {},
     create: {
       id: organizationId02,

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -501,6 +501,7 @@ async function main() {
   console.log({ superAdmin, manager, operator });
 
   // Todo
+  await prisma.todo.deleteMany({});
   const todoId01 = uuidv4();
   const todoId02 = uuidv4();
   const todoId03 = uuidv4();

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -506,6 +506,20 @@ async function main() {
   const todoId02 = uuidv4();
   const todoId03 = uuidv4();
   const todoId04 = uuidv4();
+  const todoId05 = uuidv4();
+  const todoId06 = uuidv4();
+  const todoId07 = uuidv4();
+  const todoId08 = uuidv4();
+  const todoId09 = uuidv4();
+  const todoId10 = uuidv4();
+  const todoId11 = uuidv4();
+  const todoId12 = uuidv4();
+  const todoId13 = uuidv4();
+  const todoId14 = uuidv4();
+  const todoId15 = uuidv4();
+  const todoId16 = uuidv4();
+  const todoId17 = uuidv4();
+
   const todo01 = await prisma.todo.upsert({
     where: { id: todoId01 },
     update: {},
@@ -527,7 +541,7 @@ async function main() {
       title: "テストタスク02",
       description: "テストタスク02の説明",
       organizationId: organization01.id,
-      status: "InProgress",
+      status: "NotStarted",
       createdAt: new Date(),
       updatedAt: new Date(),
     },
@@ -540,7 +554,7 @@ async function main() {
       title: "テストタスク03",
       description: "テストタスク03の説明",
       organizationId: organization01.id,
-      status: "Completed",
+      status: "NotStarted",
       createdAt: new Date(),
       updatedAt: new Date(),
     },
@@ -553,12 +567,199 @@ async function main() {
       title: "テストタスク04",
       description: "テストタスク04の説明",
       organizationId: organization01.id,
+      status: "InProgress",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo05 = await prisma.todo.upsert({
+    where: { id: todoId05 },
+    update: {},
+    create: {
+      id: todoId05,
+      title: "テストタスク05",
+      description: "テストタスク05の説明",
+      organizationId: organization01.id,
       status: "NotStarted",
       createdAt: new Date(),
       updatedAt: new Date(),
     },
   });
-  console.log({ todo01, todo02, todo03, todo04 });
+  const todo06 = await prisma.todo.upsert({
+    where: { id: todoId06 },
+    update: {},
+    create: {
+      id: todoId06,
+      title: "テストタスク06",
+      description: "テストタスク06の説明",
+      organizationId: organization01.id,
+      status: "NotStarted",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo07 = await prisma.todo.upsert({
+    where: { id: todoId07 },
+    update: {},
+    create: {
+      id: todoId07,
+      title: "テストタスク07",
+      description: "テストタスク07の説明",
+      organizationId: organization01.id,
+      status: "InProgress",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo08 = await prisma.todo.upsert({
+    where: { id: todoId08 },
+    update: {},
+    create: {
+      id: todoId08,
+      title: "テストタスク08",
+      description: "テストタスク08の説明",
+      organizationId: organization01.id,
+      status: "Completed",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo09 = await prisma.todo.upsert({
+    where: { id: todoId09 },
+    update: {},
+    create: {
+      id: todoId09,
+      title: "テストタスク09",
+      description: "テストタスク09の説明",
+      organizationId: organization01.id,
+      status: "Completed",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo10 = await prisma.todo.upsert({
+    where: { id: todoId10 },
+    update: {},
+    create: {
+      id: todoId10,
+      title: "テストタスク10",
+      description: "テストタスク10の説明",
+      organizationId: organization01.id,
+      status: "NotStarted",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo11 = await prisma.todo.upsert({
+    where: { id: todoId11 },
+    update: {},
+    create: {
+      id: todoId11,
+      title: "テストタスク11",
+      description: "テストタスク11の説明",
+      organizationId: organization01.id,
+      status: "InProgress",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo12 = await prisma.todo.upsert({
+    where: { id: todoId12 },
+    update: {},
+    create: {
+      id: todoId12,
+      title: "テストタスク12",
+      description: "テストタスク12の説明",
+      organizationId: organization01.id,
+      status: "NotStarted",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo13 = await prisma.todo.upsert({
+    where: { id: todoId13 },
+    update: {},
+    create: {
+      id: todoId13,
+      title: "テストタスク13",
+      description: "テストタスク13の説明",
+      organizationId: organization01.id,
+      status: "InProgress",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo14 = await prisma.todo.upsert({
+    where: { id: todoId14 },
+    update: {},
+    create: {
+      id: todoId14,
+      title: "テストタスク14",
+      description: "テストタスク14の説明",
+      organizationId: organization01.id,
+      status: "Completed",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo15 = await prisma.todo.upsert({
+    where: { id: todoId15 },
+    update: {},
+    create: {
+      id: todoId15,
+      title: "テストタスク15",
+      description: "テストタスク15の説明",
+      organizationId: organization01.id,
+      status: "Completed",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo16 = await prisma.todo.upsert({
+    where: { id: todoId16 },
+    update: {},
+    create: {
+      id: todoId16,
+      title: "テストタスク16",
+      description: "テストタスク16の説明",
+      organizationId: organization01.id,
+      status: "NotStarted",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo17 = await prisma.todo.upsert({
+    where: { id: todoId17 },
+    update: {},
+    create: {
+      id: todoId17,
+      title: "テストタスク17",
+      description: "テストタスク17の説明",
+      organizationId: organization01.id,
+      status: "Completed",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  console.log({
+    todo01,
+    todo02,
+    todo03,
+    todo04,
+    todo05,
+    todo06,
+    todo07,
+    todo08,
+    todo09,
+    todo10,
+    todo11,
+    todo12,
+    todo13,
+    todo14,
+    todo15,
+    todo16,
+    todo17,
+  });
 }
 main()
   .then(async () => {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -444,6 +444,65 @@ async function main() {
     },
   });
   console.log({ superAdmin, manager, operator });
+
+  // Todo
+  const todoId01 = uuidv4();
+  const todoId02 = uuidv4();
+  const todoId03 = uuidv4();
+  const todoId04 = uuidv4();
+  const todo01 = await prisma.todo.upsert({
+    where: { id: todoId01 },
+    update: {},
+    create: {
+      id: todoId01,
+      title: "テストタスク01",
+      description: "テストタスク01の説明",
+      organizationId: organization01.id,
+      status: "NotStarted",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo02 = await prisma.todo.upsert({
+    where: { id: todoId02 },
+    update: {},
+    create: {
+      id: todoId02,
+      title: "テストタスク02",
+      description: "テストタスク02の説明",
+      organizationId: organization01.id,
+      status: "InProgress",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo03 = await prisma.todo.upsert({
+    where: { id: todoId03 },
+    update: {},
+    create: {
+      id: todoId03,
+      title: "テストタスク03",
+      description: "テストタスク03の説明",
+      organizationId: organization01.id,
+      status: "Completed",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  const todo04 = await prisma.todo.upsert({
+    where: { id: todoId04 },
+    update: {},
+    create: {
+      id: todoId04,
+      title: "テストタスク04",
+      description: "テストタスク04の説明",
+      organizationId: organization01.id,
+      status: "NotStarted",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+  console.log({ todo01, todo02, todo03, todo04 });
 }
 main()
   .then(async () => {

--- a/backend/src/domain/authorization/permission.ts
+++ b/backend/src/domain/authorization/permission.ts
@@ -8,7 +8,7 @@ export type Actor = Account & {
   permissions: Array<Permission>;
 };
 export type Action = "create" | "read" | "update" | "delete" | "readAll";
-export type Resource = "Account" | "Organization";
+export type Resource = "Account" | "Organization" | "Todo";
 
 export interface PermissionService {
   getPermission(role: Role): Promise<Result<Array<Permission>, AppError>>;

--- a/backend/src/domain/todo/todo-repository.ts
+++ b/backend/src/domain/todo/todo-repository.ts
@@ -1,5 +1,5 @@
 import type { Result } from "neverthrow";
-import type { TodoItem } from "./todo-item.js";
+import type { TodoItem } from "./todo.js";
 
 export interface TodoRepository {
   save(todo: TodoItem): Promise<Result<TodoItem, Error>>;

--- a/backend/src/domain/todo/todo.ts
+++ b/backend/src/domain/todo/todo.ts
@@ -6,37 +6,20 @@ export class TodoItem {
   public readonly id: string;
   public readonly title: string;
   public readonly description: string;
-  public readonly organizationId: string;
   public readonly status: TodoStatus;
-  public readonly createdAt: Date;
-  public readonly updatedAt: Date;
 
-  constructor(
-    id: string,
-    title: string,
-    description: string,
-    organizationId: string,
-    status: TodoStatus,
-    createdAt: Date,
-    updatedAt: Date
-  ) {
+  constructor(id: string, title: string, description: string, status: TodoStatus) {
     this.id = id;
     this.title = title;
     this.description = description;
-    this.organizationId = organizationId;
     this.status = status;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
 
   static create(
     id: string,
     title: string,
     description: string,
-    organizationId: string,
-    status: TodoStatus,
-    createdAt: Date,
-    updatedAt: Date
+    status: TodoStatus
   ): Result<TodoItem, Error> {
     if (!id) {
       return err(new Error("ID is required"));
@@ -47,15 +30,26 @@ export class TodoItem {
     if (!description) {
       return err(new Error("Description is required"));
     }
+    return ok(new TodoItem(id, title, description, status));
+  }
+}
+
+export class TodoList {
+  public readonly organizationId: string;
+  public readonly items: Array<TodoItem>;
+
+  constructor(organizationId: string, items: Array<TodoItem>) {
+    this.organizationId = organizationId;
+    this.items = items;
+  }
+
+  static create(organizationId: string, items: Array<TodoItem>): Result<TodoList, Error> {
     if (!organizationId) {
       return err(new Error("Organization ID is required"));
     }
-    if (!createdAt) {
-      return err(new Error("Created at is required"));
+    if (!items) {
+      return err(new Error("Items are required"));
     }
-    if (!updatedAt) {
-      return err(new Error("Updated at is required"));
-    }
-    return ok(new TodoItem(id, title, description, organizationId, status, createdAt, updatedAt));
+    return ok(new TodoList(organizationId, items));
   }
 }

--- a/backend/src/domain/todo/todo.ts
+++ b/backend/src/domain/todo/todo.ts
@@ -36,20 +36,29 @@ export class TodoItem {
 
 export class TodoList {
   public readonly organizationId: string;
+  public readonly organizationName: string;
   public readonly list: Array<TodoItem>;
 
-  constructor(organizationId: string, list: Array<TodoItem>) {
+  constructor(organizationId: string, organizationName: string, list: Array<TodoItem>) {
     this.organizationId = organizationId;
+    this.organizationName = organizationName;
     this.list = list;
   }
 
-  static create(organizationId: string, list: Array<TodoItem>): Result<TodoList, Error> {
+  static create(
+    organizationId: string,
+    organizationName: string,
+    list: Array<TodoItem>
+  ): Result<TodoList, Error> {
     if (!organizationId) {
       return err(new Error("Organization ID is required"));
+    }
+    if (!organizationName) {
+      return err(new Error("Organization Name is required"));
     }
     if (!list) {
       return err(new Error("Items are required"));
     }
-    return ok(new TodoList(organizationId, list));
+    return ok(new TodoList(organizationId, organizationName, list));
   }
 }

--- a/backend/src/domain/todo/todo.ts
+++ b/backend/src/domain/todo/todo.ts
@@ -36,20 +36,20 @@ export class TodoItem {
 
 export class TodoList {
   public readonly organizationId: string;
-  public readonly items: Array<TodoItem>;
+  public readonly list: Array<TodoItem>;
 
-  constructor(organizationId: string, items: Array<TodoItem>) {
+  constructor(organizationId: string, list: Array<TodoItem>) {
     this.organizationId = organizationId;
-    this.items = items;
+    this.list = list;
   }
 
-  static create(organizationId: string, items: Array<TodoItem>): Result<TodoList, Error> {
+  static create(organizationId: string, list: Array<TodoItem>): Result<TodoList, Error> {
     if (!organizationId) {
       return err(new Error("Organization ID is required"));
     }
-    if (!items) {
+    if (!list) {
       return err(new Error("Items are required"));
     }
-    return ok(new TodoList(organizationId, items));
+    return ok(new TodoList(organizationId, list));
   }
 }

--- a/backend/src/errors/errors.ts
+++ b/backend/src/errors/errors.ts
@@ -46,6 +46,13 @@ export class DuplicateUserIdError extends AppError {
   readonly message = "Conflict";
 }
 
+/* todo */
+
+export class NoTodoItemError extends AppError {
+  readonly statusCode = 404;
+  readonly message = "Not Found";
+}
+
 /* 共通 */
 
 export class BadRequestError extends AppError {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import { PermissionServiceImpl } from "./infrastructure/authorization/permission
 import { OrganizationRepositoryImpl } from "./infrastructure/organization/organization-repository-impl.js";
 import { AuthHandler } from "./presentation/handlers/auth-handler.js";
 import { OrganizationHandler } from "./presentation/handlers/organization-handler.js";
+import { TodoHandler } from "./presentation/handlers/todo-handler.js";
 import { UserHandler } from "./presentation/handlers/user-handler.js";
 import { LoggerMiddleware } from "./presentation/middleware/logger.js";
 import type { Env } from "./presentation/middleware/logger.js";
@@ -19,6 +20,7 @@ import { OrganizationDeleteCommandImpl } from "./usecase/organization/command/de
 import { OrganizationUpdateCommandImpl } from "./usecase/organization/command/update.js";
 import { OrganizationListQueryImpl } from "./usecase/organization/query/get-list.js";
 import { OrganizationProfileQueryImpl } from "./usecase/organization/query/get-profile.js";
+import { TodoListQueryImpl } from "./usecase/todo/query/get-list.js";
 import { UserCreateCommandImpl } from "./usecase/user/command/create.js";
 import { UserDeleteCommandImpl } from "./usecase/user/command/delete.js";
 import { UserUpdateRoleCommandImpl } from "./usecase/user/command/update-role.js";
@@ -60,6 +62,7 @@ const userCreateCommand = new UserCreateCommandImpl(
   organizationRepository,
   passwordHash
 );
+
 const userUpdateCommand = new UserUpdateCommandImpl(accountRepository, passwordHash);
 const userUpdateRoleCommand = new UserUpdateRoleCommandImpl(accountRepository);
 const userDeleteCommand = new UserDeleteCommandImpl(accountRepository);
@@ -71,7 +74,10 @@ const userHandler = new UserHandler(
   userDeleteCommand
 );
 
-initRouting(app, authHandler, organizationHandler, userHandler, jwtService);
+const todoListQuery = new TodoListQueryImpl();
+const todoHandler = new TodoHandler(todoListQuery);
+
+initRouting(app, authHandler, organizationHandler, userHandler, todoHandler, jwtService);
 
 serve(
   {

--- a/backend/src/presentation/handlers/todo-handler.ts
+++ b/backend/src/presentation/handlers/todo-handler.ts
@@ -6,9 +6,8 @@ export class TodoHandler {
 
   async getTodoList(c: Context) {
     const organizationId = c.req.param("id");
-    const actor = c.get("actor");
 
-    const result = await this.todoListQuery.execute(organizationId, actor);
+    const result = await this.todoListQuery.execute(organizationId, c.get("actor"));
 
     if (result.isErr()) {
       c.get("logger").error("TodoListQuery failed", {

--- a/backend/src/presentation/handlers/todo-handler.ts
+++ b/backend/src/presentation/handlers/todo-handler.ts
@@ -1,5 +1,3 @@
-import { Account } from "@/domain/account/account.js";
-import { UnexpectedError } from "@/errors/errors.js";
 import type { TodoListQuery } from "@/usecase/todo/query/get-list.js";
 import type { Context } from "hono";
 
@@ -8,21 +6,9 @@ export class TodoHandler {
 
   async getTodoList(c: Context) {
     const organizationId = c.req.param("id");
-    const actorWithPermissions = c.get("actorWithPermissions");
-    const actor = Account.create(
-      actorWithPermissions.id,
-      actorWithPermissions.userId,
-      actorWithPermissions.name,
-      actorWithPermissions.hashedPassword,
-      actorWithPermissions.organizationId,
-      actorWithPermissions.role
-    );
-    if (actor.isErr()) {
-      const error = new UnexpectedError(actor.error.message);
-      return c.json({ message: error.message }, error.statusCode);
-    }
+    const actor = c.get("actor");
 
-    const result = await this.todoListQuery.execute(organizationId, actor.value);
+    const result = await this.todoListQuery.execute(organizationId, actor);
 
     if (result.isErr()) {
       c.get("logger").error("TodoListQuery failed", {

--- a/backend/src/presentation/handlers/todo-handler.ts
+++ b/backend/src/presentation/handlers/todo-handler.ts
@@ -1,0 +1,38 @@
+import { Account } from "@/domain/account/account.js";
+import { UnexpectedError } from "@/errors/errors.js";
+import type { TodoListQuery } from "@/usecase/todo/query/get-list.js";
+import type { Context } from "hono";
+
+export class TodoHandler {
+  constructor(private readonly todoListQuery: TodoListQuery) {}
+
+  async getTodoList(c: Context) {
+    const organizationId = c.req.param("id");
+    const actorWithPermissions = c.get("actorWithPermissions");
+    const actor = Account.create(
+      actorWithPermissions.id,
+      actorWithPermissions.userId,
+      actorWithPermissions.name,
+      actorWithPermissions.hashedPassword,
+      actorWithPermissions.organizationId,
+      actorWithPermissions.role
+    );
+    if (actor.isErr()) {
+      const error = new UnexpectedError(actor.error.message);
+      return c.json({ message: error.message }, error.statusCode);
+    }
+
+    const result = await this.todoListQuery.execute(organizationId, actor.value);
+
+    if (result.isErr()) {
+      c.get("logger").error("TodoListQuery failed", {
+        error: result.error.constructor.name,
+        message: result.error.message,
+        statusCode: result.error.statusCode,
+      });
+      return c.json({ message: result.error.message }, result.error.statusCode);
+    }
+
+    return c.json(result.value, 200);
+  }
+}

--- a/backend/src/presentation/routes.ts
+++ b/backend/src/presentation/routes.ts
@@ -6,6 +6,7 @@ import type { Hono } from "hono";
 import { z } from "zod";
 import type { AuthHandler } from "./handlers/auth-handler.js";
 import type { OrganizationHandler } from "./handlers/organization-handler.js";
+import type { TodoHandler } from "./handlers/todo-handler.js";
 import type { UserHandler } from "./handlers/user-handler.js";
 import { jwtMiddleware } from "./middleware/jwt.js";
 import type { Env } from "./middleware/logger.js";
@@ -16,6 +17,7 @@ export function initRouting(
   authHandler: AuthHandler,
   organizationHandler: OrganizationHandler,
   userHandler: UserHandler,
+  todoHandler: TodoHandler,
   jwtService: JwtService
 ) {
   app.get("/", (c) => {
@@ -171,5 +173,19 @@ export function initRouting(
     jwtMiddleware(jwtService),
     permissionMiddleware("delete", "Account"),
     (c) => userHandler.deleteUser(c)
+  );
+
+  /* Todo */
+  app.get(
+    "/todo-list/:id",
+    zValidator("param", z.object({ id: z.string().uuid() }), (result, c) => {
+      if (!result.success) {
+        const error = new BadRequestError();
+        return c.json({ message: error.message }, error.statusCode);
+      }
+    }),
+    jwtMiddleware(jwtService),
+    permissionMiddleware("read", "Todo"),
+    (c) => todoHandler.getTodoList(c)
   );
 }

--- a/backend/src/usecase/todo/query/get-list.test.ts
+++ b/backend/src/usecase/todo/query/get-list.test.ts
@@ -1,0 +1,146 @@
+import { Account } from "@/domain/account/account.js";
+import type { TodoItem } from "@/domain/todo/todo.js";
+import {
+  ForbiddenError,
+  NoOrganizationError,
+  NoTodoItemError,
+  UnexpectedError,
+} from "@/errors/errors.js";
+import { PrismaClient } from "@/generated/prisma/index.js";
+import { err } from "neverthrow";
+import { describe, expect, it, vi } from "vitest";
+import { TodoListQueryImpl } from "./get-list.js";
+
+const mockPrismaClient = {
+  organization: {
+    findUnique: vi.fn(),
+  },
+};
+
+vi.mock("@/generated/prisma/index.js", () => ({
+  PrismaClient: vi.fn(() => mockPrismaClient),
+}));
+
+describe("TodoListQueryImpl", () => {
+  const prisma = new PrismaClient();
+  const mockFindUnique = prisma.organization.findUnique;
+
+  it("正常にタスク一覧を取得", async () => {
+    const todoListQuery = new TodoListQueryImpl();
+    const organizationId = "mock-uuid-123";
+    const mockTodos = [
+      {
+        id: "mock-uuid-todo-01",
+        title: "テストタスク01",
+        description: "テストタスク01の説明",
+        status: "NotStarted",
+      },
+      {
+        id: "mock-uuid-todo-02",
+        title: "テストタスク02",
+        description: "テストタスク02の説明",
+        status: "InProgress",
+      },
+    ];
+
+    const mockActor = Account.create(
+      "mock-uuid-user-01",
+      "user-01",
+      "テストユーザー01",
+      "password",
+      organizationId,
+      "Manager"
+    )._unsafeUnwrap();
+
+    mockPrismaClient.organization.findUnique.mockResolvedValue({
+      id: organizationId,
+      todos: mockTodos,
+    });
+
+    const result = await todoListQuery.execute(organizationId, mockActor);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const todoList = result.value;
+      expect(todoList.organizationId).toBe(organizationId);
+      expect(todoList.items).toEqual(mockTodos);
+      expect(mockFindUnique).toHaveBeenCalledWith({
+        where: { id: organizationId },
+        include: { todos: true },
+      });
+    }
+  });
+
+  it("Manager以下のユーザーが組織に所属していない場合", async () => {
+    const todoListQuery = new TodoListQueryImpl();
+    const organizationId = "mock-uuid-123";
+    const mockActor = Account.create(
+      "mock-uuid-user-01",
+      "user-01",
+      "テストユーザー01",
+      "password",
+      "mock-uuid-456",
+      "Manager"
+    )._unsafeUnwrap();
+
+    const result = await todoListQuery.execute(organizationId, mockActor);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ForbiddenError);
+    }
+  });
+
+  it("組織が存在しない場合", async () => {
+    const todoListQuery = new TodoListQueryImpl();
+    const organizationId = "mock-uuid-123";
+    const mockActor = Account.create(
+      "mock-uuid-user-01",
+      "user-01",
+      "テストユーザー01",
+      "password",
+      organizationId,
+      "Manager"
+    )._unsafeUnwrap();
+
+    mockPrismaClient.organization.findUnique.mockResolvedValue(null);
+
+    const result = await todoListQuery.execute(organizationId, mockActor);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NoOrganizationError);
+      expect(mockFindUnique).toHaveBeenCalledWith({
+        where: { id: organizationId },
+        include: { todos: true },
+      });
+    }
+  });
+
+  it("Todoアイテムが存在しない場合", async () => {
+    const todoListQuery = new TodoListQueryImpl();
+    const organizationId = "mock-uuid-123";
+    const mockTodos: Array<TodoItem> = [];
+
+    const mockActor = Account.create(
+      "mock-uuid-user-01",
+      "user-01",
+      "テストユーザー01",
+      "password",
+      organizationId,
+      "Manager"
+    )._unsafeUnwrap();
+
+    mockPrismaClient.organization.findUnique.mockResolvedValue({
+      id: organizationId,
+      todos: mockTodos,
+    });
+
+    const result = await todoListQuery.execute(organizationId, mockActor);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NoTodoItemError);
+      expect(mockFindUnique).toHaveBeenCalledWith({
+        where: { id: organizationId },
+        include: { todos: true },
+      });
+    }
+  });
+});

--- a/backend/src/usecase/todo/query/get-list.test.ts
+++ b/backend/src/usecase/todo/query/get-list.test.ts
@@ -134,40 +134,4 @@ describe("TodoListQueryImpl", () => {
       });
     }
   });
-
-  it("Todoアイテムが存在しない場合", async () => {
-    const todoListQuery = new TodoListQueryImpl();
-    const organizationId = "mock-uuid-123";
-    const mockTodos: Array<TodoItem> = [];
-
-    const mockAccount = Account.create(
-      "mock-uuid-user-01",
-      "user-01",
-      "テストユーザー01",
-      "password",
-      organizationId,
-      "Manager"
-    )._unsafeUnwrap();
-
-    const mockActor: Actor = {
-      ...mockAccount,
-      permissions: ["read:Todo"],
-      update: mockAccount.update,
-    };
-
-    mockPrismaClient.organization.findUnique.mockResolvedValue({
-      id: organizationId,
-      todos: mockTodos,
-    });
-
-    const result = await todoListQuery.execute(organizationId, mockActor);
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error).toBeInstanceOf(NoTodoItemError);
-      expect(mockFindUnique).toHaveBeenCalledWith({
-        where: { id: organizationId },
-        include: { todos: true },
-      });
-    }
-  });
 });

--- a/backend/src/usecase/todo/query/get-list.test.ts
+++ b/backend/src/usecase/todo/query/get-list.test.ts
@@ -1,4 +1,5 @@
 import { Account } from "@/domain/account/account.js";
+import type { Actor } from "@/domain/authorization/permission.js";
 import type { TodoItem } from "@/domain/todo/todo.js";
 import {
   ForbiddenError,
@@ -7,7 +8,6 @@ import {
   UnexpectedError,
 } from "@/errors/errors.js";
 import { PrismaClient } from "@/generated/prisma/index.js";
-import { err } from "neverthrow";
 import { describe, expect, it, vi } from "vitest";
 import { TodoListQueryImpl } from "./get-list.js";
 
@@ -43,7 +43,7 @@ describe("TodoListQueryImpl", () => {
       },
     ];
 
-    const mockActor = Account.create(
+    const mockAccount = Account.create(
       "mock-uuid-user-01",
       "user-01",
       "テストユーザー01",
@@ -51,6 +51,12 @@ describe("TodoListQueryImpl", () => {
       organizationId,
       "Manager"
     )._unsafeUnwrap();
+
+    const mockActor: Actor = {
+      ...mockAccount,
+      permissions: ["read:Todo"],
+      update: mockAccount.update,
+    };
 
     mockPrismaClient.organization.findUnique.mockResolvedValue({
       id: organizationId,
@@ -62,7 +68,7 @@ describe("TodoListQueryImpl", () => {
     if (result.isOk()) {
       const todoList = result.value;
       expect(todoList.organizationId).toBe(organizationId);
-      expect(todoList.items).toEqual(mockTodos);
+      expect(todoList.list).toEqual(mockTodos);
       expect(mockFindUnique).toHaveBeenCalledWith({
         where: { id: organizationId },
         include: { todos: true },
@@ -73,7 +79,7 @@ describe("TodoListQueryImpl", () => {
   it("Manager以下のユーザーが組織に所属していない場合", async () => {
     const todoListQuery = new TodoListQueryImpl();
     const organizationId = "mock-uuid-123";
-    const mockActor = Account.create(
+    const mockAccount = Account.create(
       "mock-uuid-user-01",
       "user-01",
       "テストユーザー01",
@@ -81,6 +87,12 @@ describe("TodoListQueryImpl", () => {
       "mock-uuid-456",
       "Manager"
     )._unsafeUnwrap();
+
+    const mockActor: Actor = {
+      ...mockAccount,
+      permissions: ["read:Todo"],
+      update: mockAccount.update,
+    };
 
     const result = await todoListQuery.execute(organizationId, mockActor);
     expect(result.isErr()).toBe(true);
@@ -92,7 +104,7 @@ describe("TodoListQueryImpl", () => {
   it("組織が存在しない場合", async () => {
     const todoListQuery = new TodoListQueryImpl();
     const organizationId = "mock-uuid-123";
-    const mockActor = Account.create(
+    const mockAccount = Account.create(
       "mock-uuid-user-01",
       "user-01",
       "テストユーザー01",
@@ -100,6 +112,12 @@ describe("TodoListQueryImpl", () => {
       organizationId,
       "Manager"
     )._unsafeUnwrap();
+
+    const mockActor: Actor = {
+      ...mockAccount,
+      permissions: ["read:Todo"],
+      update: mockAccount.update,
+    };
 
     mockPrismaClient.organization.findUnique.mockResolvedValue(null);
 
@@ -119,7 +137,7 @@ describe("TodoListQueryImpl", () => {
     const organizationId = "mock-uuid-123";
     const mockTodos: Array<TodoItem> = [];
 
-    const mockActor = Account.create(
+    const mockAccount = Account.create(
       "mock-uuid-user-01",
       "user-01",
       "テストユーザー01",
@@ -127,6 +145,12 @@ describe("TodoListQueryImpl", () => {
       organizationId,
       "Manager"
     )._unsafeUnwrap();
+
+    const mockActor: Actor = {
+      ...mockAccount,
+      permissions: ["read:Todo"],
+      update: mockAccount.update,
+    };
 
     mockPrismaClient.organization.findUnique.mockResolvedValue({
       id: organizationId,

--- a/backend/src/usecase/todo/query/get-list.test.ts
+++ b/backend/src/usecase/todo/query/get-list.test.ts
@@ -28,6 +28,7 @@ describe("TodoListQueryImpl", () => {
   it("正常にタスク一覧を取得", async () => {
     const todoListQuery = new TodoListQueryImpl();
     const organizationId = "mock-uuid-123";
+    const organizationName = "テスト組織01";
     const mockTodos = [
       {
         id: "mock-uuid-todo-01",
@@ -60,6 +61,7 @@ describe("TodoListQueryImpl", () => {
 
     mockPrismaClient.organization.findUnique.mockResolvedValue({
       id: organizationId,
+      name: organizationName,
       todos: mockTodos,
     });
 
@@ -68,6 +70,7 @@ describe("TodoListQueryImpl", () => {
     if (result.isOk()) {
       const todoList = result.value;
       expect(todoList.organizationId).toBe(organizationId);
+      expect(todoList.organizationName).toBe(organizationName);
       expect(todoList.list).toEqual(mockTodos);
       expect(mockFindUnique).toHaveBeenCalledWith({
         where: { id: organizationId },

--- a/backend/src/usecase/todo/query/get-list.ts
+++ b/backend/src/usecase/todo/query/get-list.ts
@@ -54,7 +54,7 @@ export class TodoListQueryImpl implements TodoListQuery {
       validItems.push(item.value);
     }
 
-    const list = TodoList.create(organizationId, validItems);
+    const list = TodoList.create(organizationId, organizationWithTodos.name, validItems);
     if (list.isErr()) {
       return err(new UnexpectedError());
     }

--- a/backend/src/usecase/todo/query/get-list.ts
+++ b/backend/src/usecase/todo/query/get-list.ts
@@ -39,9 +39,6 @@ export class TodoListQueryImpl implements TodoListQuery {
 
     const datas = organizationWithTodos.todos;
 
-    if (datas.length === 0) {
-      return err(new NoTodoItemError());
-    }
     const items = datas.map((data) =>
       TodoItem.create(data.id, data.title, data.description, data.status)
     );

--- a/backend/src/usecase/todo/query/get-list.ts
+++ b/backend/src/usecase/todo/query/get-list.ts
@@ -1,4 +1,4 @@
-import type { Account } from "@/domain/account/account.js";
+import type { Actor } from "@/domain/authorization/permission.js";
 import { TodoItem, TodoList } from "@/domain/todo/todo.js";
 import {
   type AppError,
@@ -11,13 +11,13 @@ import { PrismaClient } from "@/generated/prisma/index.js";
 import { type Result, err, ok } from "neverthrow";
 
 export interface TodoListQuery {
-  execute(organizationId: string, actor: Account): Promise<Result<TodoList, AppError>>;
+  execute(organizationId: string, actor: Actor): Promise<Result<TodoList, AppError>>;
 }
 
 export class TodoListQueryImpl implements TodoListQuery {
   private prisma = new PrismaClient();
 
-  async execute(organizationId: string, actor: Account): Promise<Result<TodoList, AppError>> {
+  async execute(organizationId: string, actor: Actor): Promise<Result<TodoList, AppError>> {
     if (
       (actor.role === "Manager" || actor.role === "Operator") &&
       actor.organizationId !== organizationId

--- a/backend/src/usecase/todo/query/get-list.ts
+++ b/backend/src/usecase/todo/query/get-list.ts
@@ -1,0 +1,63 @@
+import type { Account } from "@/domain/account/account.js";
+import { TodoItem, TodoList } from "@/domain/todo/todo.js";
+import {
+  type AppError,
+  ForbiddenError,
+  NoOrganizationError,
+  NoTodoItemError,
+  UnexpectedError,
+} from "@/errors/errors.js";
+import { PrismaClient } from "@/generated/prisma/index.js";
+import { type Result, err, ok } from "neverthrow";
+
+export interface TodoListQuery {
+  execute(organizationId: string, actor: Account): Promise<Result<TodoList, AppError>>;
+}
+
+export class TodoListQueryImpl implements TodoListQuery {
+  private prisma = new PrismaClient();
+
+  async execute(organizationId: string, actor: Account): Promise<Result<TodoList, AppError>> {
+    if (
+      (actor.role === "Manager" || actor.role === "Operator") &&
+      actor.organizationId !== organizationId
+    ) {
+      return err(new ForbiddenError());
+    }
+
+    const organizationWithTodos = await this.prisma.organization.findUnique({
+      where: {
+        id: organizationId,
+      },
+      include: {
+        todos: true,
+      },
+    });
+    if (!organizationWithTodos) {
+      return err(new NoOrganizationError());
+    }
+
+    const datas = organizationWithTodos.todos;
+
+    if (datas.length === 0) {
+      return err(new NoTodoItemError());
+    }
+    const items = datas.map((data) =>
+      TodoItem.create(data.id, data.title, data.description, data.status)
+    );
+
+    const validItems: Array<TodoItem> = [];
+    for (const item of items) {
+      if (item.isErr()) {
+        return err(new UnexpectedError());
+      }
+      validItems.push(item.value);
+    }
+
+    const list = TodoList.create(organizationId, validItems);
+    if (list.isErr()) {
+      return err(new UnexpectedError());
+    }
+    return ok(list.value);
+  }
+}

--- a/frontend/src/features/todo/index.tsx
+++ b/frontend/src/features/todo/index.tsx
@@ -1,0 +1,16 @@
+import type { TodoGetListResponse } from "@/client/types.gen";
+
+export const Todo = ({ todoList }: { todoList?: TodoGetListResponse }) => {
+  return (
+    <div>
+      <div>
+        <h1>Todoリスト</h1>
+      </div>
+      <div>
+        {todoList?.list.map((todo) => (
+          <div key={todo.id}>{todo.title}</div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/todo/index.tsx
+++ b/frontend/src/features/todo/index.tsx
@@ -1,15 +1,75 @@
 import type { TodoGetListResponse } from "@/client/types.gen";
 
+const statusColor = (status?: string) => {
+  switch (status) {
+    case "NotStarted":
+      return "bg-orange-100 text-orange-800";
+    case "InProgress":
+      return "bg-yellow-100 text-yellow-800";
+    case "Completed":
+      return "bg-green-100 text-green-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
+};
+
 export const Todo = ({ todoList }: { todoList?: TodoGetListResponse }) => {
   return (
-    <div>
-      <div>
-        <h1>Todoリスト</h1>
+    <div className="min-h-screen p-6">
+      <div className="max-w-7xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4 text-gray-900">{todoList?.organizationName}</h1>
+        <div className="flex flex-row gap-4">
+          <TodoCulumn
+            list={todoList?.list.filter((todo) => todo.status === "NotStarted") ?? []}
+            status="未着手"
+          />
+          <TodoCulumn
+            list={todoList?.list.filter((todo) => todo.status === "InProgress") ?? []}
+            status="進行中"
+          />
+          <TodoCulumn
+            list={todoList?.list.filter((todo) => todo.status === "Completed") ?? []}
+            status="完了"
+          />
+        </div>
       </div>
-      <div>
-        {todoList?.list.map((todo) => (
-          <div key={todo.id}>{todo.title}</div>
-        ))}
+    </div>
+  );
+};
+
+const TodoCulumn = ({ list, status }: { list: TodoGetListResponse["list"]; status: string }) => {
+  return (
+    <div className="w-full">
+      <h2 className="text-gray-500 text-l font-bold pl-2 mb-2">{status}</h2>
+      <div className="space-y-2 overflow-y-auto pb-2 w-full h-[calc(100vh-180px)]">
+        {list.length ? (
+          list.map((todo) => (
+            <div
+              key={todo.id}
+              className="flex flex-col md:flex-row md:items-center justify-between bg-white rounded-lg cursor-pointer shadow p-4 border hover:bg-gray-100 transition"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-lg font-semibold text-gray-800">{todo.title}</span>
+                </div>
+                <div className="mt-1 text-gray-600 text-sm break-words">
+                  {todo.description ?? <span className="text-gray-400">説明なし</span>}
+                </div>
+              </div>
+              <div className="mt-3 md:mt-0 md:ml-6 flex-shrink-0">
+                <span
+                  className={`inline-block px-3 py-1 rounded-full text-xs font-medium ${statusColor(
+                    todo.status
+                  )}`}
+                >
+                  {status}
+                </span>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="text-gray-500 text-center py-10">タスクはありません</div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/features/todo/index.tsx
+++ b/frontend/src/features/todo/index.tsx
@@ -1,75 +1,49 @@
-import type { TodoGetListResponse } from "@/client/types.gen";
+import type { OrganizationApiGetListResponse } from "@/client/types.gen";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useNavigate } from "@tanstack/react-router";
 
-const statusColor = (status?: string) => {
-  switch (status) {
-    case "NotStarted":
-      return "bg-orange-100 text-orange-800";
-    case "InProgress":
-      return "bg-yellow-100 text-yellow-800";
-    case "Completed":
-      return "bg-green-100 text-green-800";
-    default:
-      return "bg-gray-100 text-gray-800";
-  }
-};
-
-export const Todo = ({ todoList }: { todoList?: TodoGetListResponse }) => {
+export const TodoOrganizationList = ({
+  organizationList,
+}: { organizationList: OrganizationApiGetListResponse }) => {
+  const navigate = useNavigate();
   return (
-    <div className="min-h-screen p-6">
-      <div className="max-w-7xl mx-auto">
-        <h1 className="text-2xl font-bold mb-4 text-gray-900">{todoList?.organizationName}</h1>
-        <div className="flex flex-row gap-4">
-          <TodoCulumn
-            list={todoList?.list.filter((todo) => todo.status === "NotStarted") ?? []}
-            status="未着手"
-          />
-          <TodoCulumn
-            list={todoList?.list.filter((todo) => todo.status === "InProgress") ?? []}
-            status="進行中"
-          />
-          <TodoCulumn
-            list={todoList?.list.filter((todo) => todo.status === "Completed") ?? []}
-            status="完了"
-          />
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50 p-6">
+      <div className="max-w-6xl mx-auto">
+        <div className="mb-2">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Todoリスト</h1>
+          <p className="text-gray-600">登録されている組織一覧</p>
         </div>
-      </div>
-    </div>
-  );
-};
-
-const TodoCulumn = ({ list, status }: { list: TodoGetListResponse["list"]; status: string }) => {
-  return (
-    <div className="w-full">
-      <h2 className="text-gray-500 text-l font-bold pl-2 mb-2">{status}</h2>
-      <div className="space-y-2 overflow-y-auto pb-2 w-full h-[calc(100vh-180px)]">
-        {list.length ? (
-          list.map((todo) => (
-            <div
-              key={todo.id}
-              className="flex flex-col md:flex-row md:items-center justify-between bg-white rounded-lg cursor-pointer shadow p-4 border hover:bg-gray-100 transition"
-            >
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="text-lg font-semibold text-gray-800">{todo.title}</span>
-                </div>
-                <div className="mt-1 text-gray-600 text-sm break-words">
-                  {todo.description ?? <span className="text-gray-400">説明なし</span>}
-                </div>
-              </div>
-              <div className="mt-3 md:mt-0 md:ml-6 flex-shrink-0">
-                <span
-                  className={`inline-block px-3 py-1 rounded-full text-xs font-medium ${statusColor(
-                    todo.status
-                  )}`}
+        <div className="bg-white rounded-lg shadow-sm border">
+          <div className="p-4 border-b">
+            <h2 className="text-l font-semibold text-gray-900">組織一覧</h2>
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>組織名</TableHead>
+                <TableHead className="w-[120px]"> </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {organizationList.map((org) => (
+                <TableRow
+                  key={org.id}
+                  className="cursor-pointer"
+                  onClick={() => navigate({ to: `/todo/${org.id}` })}
                 >
-                  {status}
-                </span>
-              </div>
-            </div>
-          ))
-        ) : (
-          <div className="text-gray-500 text-center py-10">タスクはありません</div>
-        )}
+                  <TableCell className="font-medium">{org.name}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/features/todo/todo.tsx
+++ b/frontend/src/features/todo/todo.tsx
@@ -1,0 +1,76 @@
+import type { TodoGetListResponse } from "@/client/types.gen";
+
+const statusColor = (status?: string) => {
+  switch (status) {
+    case "NotStarted":
+      return "bg-orange-100 text-orange-800";
+    case "InProgress":
+      return "bg-yellow-100 text-yellow-800";
+    case "Completed":
+      return "bg-green-100 text-green-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
+};
+
+export const TodoList = ({ todoList }: { todoList: TodoGetListResponse }) => {
+  return (
+    <div className="min-h-screen p-6">
+      <div className="max-w-7xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4 text-gray-900">{todoList?.organizationName}</h1>
+        <div className="flex flex-row gap-4">
+          <TodoCulumn
+            list={todoList?.list.filter((todo) => todo.status === "NotStarted") ?? []}
+            status="未着手"
+          />
+          <TodoCulumn
+            list={todoList?.list.filter((todo) => todo.status === "InProgress") ?? []}
+            status="進行中"
+          />
+          <TodoCulumn
+            list={todoList?.list.filter((todo) => todo.status === "Completed") ?? []}
+            status="完了"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const TodoCulumn = ({ list, status }: { list: TodoGetListResponse["list"]; status: string }) => {
+  return (
+    <div className="w-full">
+      <h2 className="text-gray-500 text-l font-bold pl-2 mb-2">{status}</h2>
+      <div className="space-y-2 overflow-y-auto pb-2 w-full h-[calc(100vh-180px)]">
+        {list.length ? (
+          list.map((todo) => (
+            <div
+              key={todo.id}
+              className="flex flex-col md:flex-row md:items-center justify-between bg-white rounded-lg cursor-pointer shadow p-4 border hover:bg-gray-100 transition"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-lg font-semibold text-gray-800">{todo.title}</span>
+                </div>
+                <div className="mt-1 text-gray-600 text-sm break-words">
+                  {todo.description ?? <span className="text-gray-400">説明なし</span>}
+                </div>
+              </div>
+              <div className="mt-3 md:mt-0 md:ml-6 flex-shrink-0">
+                <span
+                  className={`inline-block px-3 py-1 rounded-full text-xs font-medium ${statusColor(
+                    todo.status
+                  )}`}
+                >
+                  {status}
+                </span>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="text-gray-500 text-center py-10">タスクはありません</div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/routes/_protected.tsx
+++ b/frontend/src/routes/_protected.tsx
@@ -32,7 +32,7 @@ export const Route = createFileRoute("/_protected")({
             <NavigationMenu>
               <NavigationMenuList>
                 <NavigationMenuItem>
-                  <NavigationMenuLink href="/">HOME</NavigationMenuLink>
+                  <NavigationMenuLink href="/todo">Todoリスト</NavigationMenuLink>
                 </NavigationMenuItem>
                 <NavigationMenuItem>
                   <NavigationMenuLink href="/organization">

--- a/frontend/src/routes/_protected/todo/$organizationId.tsx
+++ b/frontend/src/routes/_protected/todo/$organizationId.tsx
@@ -1,0 +1,29 @@
+import { todoGetListOptions } from "@/client/@tanstack/react-query.gen";
+import { TodoList } from "@/features/todo/todo";
+import { queryClient } from "@/lib/query-client";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, useParams } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_protected/todo/$organizationId")({
+  loader: async ({ params }) => {
+    const { organizationId } = params;
+    await queryClient.ensureQueryData(
+      todoGetListOptions({
+        path: {
+          id: organizationId,
+        },
+      })
+    );
+  },
+  component: () => {
+    const { organizationId } = useParams({ from: "/_protected/todo/$organizationId" });
+    const { data: todoList } = useSuspenseQuery(
+      todoGetListOptions({
+        path: {
+          id: organizationId,
+        },
+      })
+    );
+    return <TodoList todoList={todoList} />;
+  },
+});

--- a/frontend/src/routes/_protected/todo/index.tsx
+++ b/frontend/src/routes/_protected/todo/index.tsx
@@ -1,0 +1,45 @@
+import { todoGetListOptions } from "@/client/@tanstack/react-query.gen";
+import { Todo } from "@/features/todo";
+import { queryClient } from "@/lib/query-client";
+import { useAuthStore } from "@/store/auth-store";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute, useLoaderData } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/_protected/todo/")({
+  loader: async () => {
+    const { account } = useAuthStore.getState();
+    if (!account) {
+      // _protected.tsxのbeforeLoadで認証チェック済みのため、理論上ここには到達しない
+      throw new Error("No Authentication Data");
+    }
+
+    // organizationIdが有効な値の場合のみクエリを実行
+    if (account.organizationId) {
+      await queryClient.ensureQueryData(
+        todoGetListOptions({
+          path: {
+            id: account.organizationId,
+          },
+        })
+      );
+    }
+
+    return { account };
+  },
+  component: () => {
+    const { account } = useLoaderData({ from: "/_protected/todo/" });
+
+    // organizationIdが有効な値の場合のみクエリを実行
+    const { data: todoList } = account.organizationId
+      ? useSuspenseQuery(
+          todoGetListOptions({
+            path: {
+              id: account.organizationId,
+            },
+          })
+        )
+      : { data: undefined };
+
+    return <Todo todoList={todoList} />;
+  },
+});

--- a/schema/main.tsp
+++ b/schema/main.tsp
@@ -3,3 +3,4 @@ import "@typespec/http";
 import "./src/auth.tsp";
 import "./src/organization.tsp";
 import "./src/user.tsp";
+import "./src/todo.tsp";

--- a/schema/src/todo.tsp
+++ b/schema/src/todo.tsp
@@ -17,6 +17,7 @@ model TodoItem {
 
 model TodoList {
   organizationId: string;
+  organizationName: string;
   list: Array<TodoItem>;
 }
 

--- a/schema/src/todo.tsp
+++ b/schema/src/todo.tsp
@@ -1,0 +1,34 @@
+import "./error.tsp";
+
+using TypeSpec.Http;
+
+enum TodoStatus {
+  notStarted: "NotStarted",
+  inProgress: "InProgress",
+  completed: "Completed",
+}
+
+model TodoItem {
+  id: string;
+  title: string;
+  description: string;
+  status: TodoStatus;
+}
+
+model TodoList {
+  organizationId: string;
+  list: Array<TodoItem>;
+}
+
+@tag("Todo")
+interface Todo {
+  @get
+  @route("/todo-list/{id}")
+  @summary("Todoリスト取得")
+  getList(@path id: string):
+    | TodoList
+    | BadRequestError
+    | ForbiddenError
+    | NotFoundError
+    | InternalServerError;
+}


### PR DESCRIPTION
## 関連Issue

<!-- 例: Closes #12 -->
Closes #18 

## 概要

<!-- このPRの目的や背景を簡潔に記載 -->
Todoリストを表示する機能をフロントエンドに実装しました。

## 変更内容

<!-- 主な変更点や実装内容を箇条書きで記載 -->
- ルーターで`/todo`, `/todo/$organizationId`を実装しました。
- 組織選択し、Todoリストを表示するように実装しました。
- 権限による画面の分岐を下記の通りとしました。
  - SuperAdmin -> 制限なし
  - Manager/Operator -> `/todo`でroute routerのbeforeLoadでauthStoreのorganizationIdのTodoリストページにリダイレクトするように修正しました。

## 確認事項

- [ ] ローカルで動作確認済み
<!-- - [ ] 必要に応じてスクリーンショットを添付した -->
<img width="1156" height="778" alt="スクリーンショット 2025-07-25 13 24 44" src="https://github.com/user-attachments/assets/49f03cec-e5a5-4aa0-8eef-430c876a875e" />
<img width="1156" height="969" alt="スクリーンショット 2025-07-25 13 25 06" src="https://github.com/user-attachments/assets/7e8ed1fd-0374-4b4f-9a65-f3989925577a" />

## 備考

<!-- レビュー時に共有しておきたいことがあれば記載 -->
