### PR TITLE
Cloud Build：frontendのデプロイ

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,28 @@
+steps:
+  - name: 'node:20'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        npm install -g pnpm
+        pnpm install --frozen-lockfile
+        pnpm build
+    dir: 'frontend'
+    secretEnv: ['VITE_API_BASE_URL']
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args:
+      - 'storage'
+      - 'rsync'
+      - 'frontend/dist/'
+      - 'gs://${_BUCKET_NAME}'
+      - '--recursive'
+
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+availableSecrets:
+  secretManager:
+  - versionName: projects/typescript-fullstack-onboard/secrets/VITE_API_BASE_URL/versions/latest
+    env: 'VITE_API_BASE_URL'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,15 +7,8 @@ steps:
         npm install -g pnpm
         pnpm install --frozen-lockfile
         pnpm apply
+        pnpm --filter frontend build
     dir: '.'
-
-  - name: 'node:20'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        pnpm build
-    dir: 'frontend'
     secretEnv: ['VITE_API_BASE_URL']
 
   - name: 'gcr.io/cloud-builders/gcloud'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,6 +6,14 @@ steps:
       - |
         npm install -g pnpm
         pnpm install --frozen-lockfile
+        pnpm apply
+    dir: '.'
+
+  - name: 'node:20'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
         pnpm build
     dir: 'frontend'
     secretEnv: ['VITE_API_BASE_URL']

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "pnpm generate:client && tsc && vite build",
     "preview": "vite preview",
     "clean": "rm -rf dist node_modules",
     "format": "biome format --write .",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "pnpm generate:client && tsc && vite build",
+    "build": "tsc && vite build",
     "preview": "vite preview",
     "clean": "rm -rf dist node_modules",
     "format": "biome format --write .",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "biome lint .",
     "check": "biome check --write .",
     "prepare": "husky",
+    "tf:login": "gcloud auth application-default login",
     "tf:init": "cd terraform/environments/prd && terraform init",
     "tf:plan": "cd terraform/environments/prd && terraform plan",
     "tf:apply": "cd terraform/environments/prd && terraform apply",

--- a/terraform/environments/prd/outputs.tf
+++ b/terraform/environments/prd/outputs.tf
@@ -2,3 +2,13 @@ output "load_balancer_ip_address" {
   description = "グローバル外部HTTPSロードバランサーのパブリックIPアドレス"
   value       = module.load_balancer.load_balancer_ip_address
 }
+
+output "static_website_bucket_name" {
+  description = "GCSバケット名"
+  value       = module.cloud_storage.bucket_name
+}
+
+output "cloudbuild_service_account_id" {
+  description = "Cloud BuildサービスアカウントのID"
+  value       = google_service_account.cloudbuild_service_account.id
+} 

--- a/terraform/environments/prd/terraform.tfvars.example
+++ b/terraform/environments/prd/terraform.tfvars.example
@@ -3,6 +3,7 @@ project_id = "typescript-fullstack-onboard"
 project_number = "998684226932"
 
 domain_name = "sandbox.keiyousya.com"
+vite_api_base_url_secret_value = "https://sandbox.keiyousya.com/api"
 
 db_user_secret_value     = "db-user"
 db_name_secret_value     = "db-name"

--- a/terraform/environments/prd/variables.tf
+++ b/terraform/environments/prd/variables.tf
@@ -30,6 +30,11 @@ variable "db_name_secret_value" {
   sensitive   = true
 }
 
+variable "vite_api_base_url_secret_value" {
+  type        = string
+  default     = "https://sandbox.keiyousya.com/api"
+}
+
 variable "app_installation_id" {
   type        = string
   default     = "78662661"

--- a/terraform/modules/cloud-build/variables.tf
+++ b/terraform/modules/cloud-build/variables.tf
@@ -32,3 +32,9 @@ variable "cloudbuild_v2_api_dependency" {
 variable "cloud_storage_dependency" {
   type        = any
 }
+variable "cloudbuild_service_account" {
+  type        = any
+}
+variable "static_website_bucket" {
+  type        = any
+}


### PR DESCRIPTION
## 関連Issue

<!-- 例: Closes #12 -->
Closes #92 

## 概要

<!-- このPRの目的や背景を簡潔に記載 -->
`cloudbuild.yaml`の作成を中心に、Cloud Buildでフロントエンドアプリケーションがデプロイされるように修正しました。

## 変更内容

<!-- 主な変更点や実装内容を箇条書きで記載 -->
- terraformでBuild Triggerを作成する際に、Cloud Storageに対して権限を付与したサービスアカウントを作成しました。
- `cloudbuild.yaml`を作成し、フロントエンドアプリケーションをビルドするスクリプトを実装しました。
  - ルートディレクトリにて全てのスクリプトを実行しました
    - pnpmのインストール
    - スキーマのコンパイル及び各アプリケーションへの複製
    - frontendアプリケーションのビルド
    - `gcloud storage rsync`により、GCSへのデプロイを実行
- terraformにて、シークレットマネージャーでフロントエンドで用いる環境変数を実装しました。

## 確認事項

- [x] 正しくデプロイされたことを確認
<!-- - [ ] 必要に応じてスクリーンショットを添付した -->

## 備考

<!-- レビュー時に共有しておきたいことがあれば記載 -->
